### PR TITLE
Fix sheet data validation, allow assisted weights, add session endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,32 @@ curl "localhost:8000/go-heavier/workouts/stats?location_id=$LOCATION_ID&exercise
 Note that the route is declared before `/workouts/{workout_id}` in the router, so
 that `stats` is not matched as a workout id.
 
+### Sessions
+
+A session is every set sharing one `workout_time`, which until now was only
+implicit in the data. `GET /go-heavier/sessions` lists them most recent first,
+and `GET /go-heavier/sessions/{workout_time}` returns one with a per exercise
+breakdown, ordered by the set each exercise started on.
+
+```bash
+curl "localhost:8000/go-heavier/sessions" | jq
+
+# sessions that included one exercise, though the totals still cover the whole session
+curl "localhost:8000/go-heavier/sessions?exercise_id=$EXERCISE_ID" | jq
+
+curl "localhost:8000/go-heavier/sessions/2026-08-20T21:20:00Z" | jq
+```
+
+| query param | default | description |
+| --- | --- | --- |
+| `location_id` | none | only list sessions at this location |
+| `exercise_id` | none | only list sessions that included this exercise |
+| `after` / `before` | none | inclusive `workout_time` bounds |
+| `page` | `1` | pages of `DEFAULT_DB_PAGE_SIZE` sessions |
+
+The path parameter is the session's `workout_time` in ISO 8601, exactly as the
+listing returns it. A time with no offset is read as UTC.
+
 ### Loading data from the Google Sheet
 
 `POST /go-heavier/migrations` runs the same load the data migrations run, upserting

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from src.routers.go_heavier import (
     exercises,
     locations,
     migrations,
+    sessions,
     workouts,
 )
 
@@ -35,3 +36,4 @@ app.include_router(exercises.router)
 app.include_router(workouts.router)
 app.include_router(config.router)
 app.include_router(migrations.router)
+app.include_router(sessions.router)

--- a/src/migration_utils/google_sheets.py
+++ b/src/migration_utils/google_sheets.py
@@ -11,6 +11,11 @@ from src.migration_utils.datetime_parsing import (
     clean_datetime_string,
     parse_sheet_datetime,
 )
+from src.migration_utils.sheet_frames import (
+    drop_incomplete_workouts,
+    drop_unmapped_columns,
+    to_frame,
+)
 from src.models.go_heavier import Exercise, Location, Workout
 
 
@@ -56,7 +61,7 @@ def load_locations_from_sheet(cfg: Config = Config()) -> List[Location]:
     locations_sheet = get_locations(cfg=cfg)
     locations: List[Location] = []
     data = locations_sheet.get_all_values()
-    df = pandas.DataFrame(data[1:], columns=data[0])
+    df = to_frame(data)
 
     df["id"] = df["id"].map(uuid.UUID)
     df["name"] = df["name"].astype(str)
@@ -73,7 +78,7 @@ def load_locations_from_sheet(cfg: Config = Config()) -> List[Location]:
         df["updated_at"].map(clean_datetime_string)
     ).replace("", None)
 
-    for row in df.to_dict(orient="records"):
+    for row in drop_unmapped_columns(df, Location).to_dict(orient="records"):
         try:
             location = Location(**row)
         except Exception as e:
@@ -89,7 +94,7 @@ def load_exercises_from_sheet(cfg: Config = Config()) -> List[Exercise]:
     exercises: List[Exercise] = []
     data = exercises_sheet.get_all_values()
 
-    df = pandas.DataFrame(data[1:], columns=data[0])
+    df = to_frame(data)
 
     df["id"] = df["id"].map(uuid.UUID)
     df["bipedal"] = df["bipedal"].astype(bool)
@@ -97,7 +102,7 @@ def load_exercises_from_sheet(cfg: Config = Config()) -> List[Exercise]:
     df["created_at"] = df["created_at"].apply(parse_sheet_datetime)
     df["updated_at"] = df["updated_at"].apply(parse_sheet_datetime)
 
-    for row in df.to_dict(orient="records"):
+    for row in drop_unmapped_columns(df, Exercise).to_dict(orient="records"):
         try:
             exercise = Exercise(**row)
         except Exception as e:
@@ -130,8 +135,7 @@ def load_workouts_from_sheet(
     workouts: List[Workout] = []
     data = workouts_sheet.get_all_values()
 
-    df = pandas.DataFrame(data[1:], columns=data[0])
-    df = df.replace("", None)
+    df = to_frame(data, blanks_as_none=True)
     df["location"] = df["location"].map(locations_mapping)
     df["exercise"] = df["exercise"].map(exercise_mapping)
 
@@ -155,7 +159,7 @@ def load_workouts_from_sheet(
         df = df[df["workout_time"] >= after]
     if before is not None:
         df = df[df["workout_time"] <= before]
-    df = df.copy()
+    df = drop_incomplete_workouts(df.copy())
 
     df["index"] = df["index"].astype(int)
     df["weight_kg"] = df["weight_kg"].astype(float)
@@ -175,6 +179,7 @@ def load_workouts_from_sheet(
     df["updated_at"] = pendulum.now("UTC")
 
     df = df.rename({"location": "location_id", "exercise": "exercise_id"}, axis=1)
+    df = drop_unmapped_columns(df, Workout)
 
     for row in df.to_dict(orient="records"):
         try:

--- a/src/migration_utils/sheet_frames.py
+++ b/src/migration_utils/sheet_frames.py
@@ -1,0 +1,89 @@
+"""Turning raw Google Sheet values into frames the models can be built from.
+
+Kept free of any database or config import so that it stays unit testable.
+"""
+
+import logging
+from typing import List
+
+import pandas
+import sqlalchemy
+
+logger = logging.getLogger(__name__)
+
+# The sheet row a value came from, tracked so that a rejected row can be named
+# in a way that can be found in the spreadsheet. Never passed to a model.
+SHEET_ROW = "sheet_row"
+
+# Without any one of these a workout cannot be built: the model requires them
+# and pandas cannot cast an empty cell to a number.
+REQUIRED_WORKOUT_VALUES = [
+    "location",
+    "exercise",
+    "workout_time",
+    "index",
+    "repetitions",
+    "weight_kg",
+]
+
+
+def to_frame(data: List[List[str]], blanks_as_none: bool = False) -> pandas.DataFrame:
+    """Build a frame from raw sheet values, dropping the rows with nothing in them.
+
+    A spreadsheet accumulates blank spacer rows between sessions and blank rows
+    off the end of the data. They are not records, and for workouts a blank row
+    left in place would inherit the session above it through the forward fill
+    and shift the set numbering of the rows below it.
+
+    ``blanks_as_none`` is opt in because a caller that casts a column with
+    astype(str) would otherwise turn an empty cell into the string "None".
+    """
+    df = pandas.DataFrame(data[1:], columns=data[0])
+    df[SHEET_ROW] = range(2, len(df) + 2)
+
+    values = df.drop(columns=SHEET_ROW)
+    blank = values.map(lambda cell: cell is None or str(cell).strip() == "").all(axis=1)
+    if blank.any():
+        logger.debug(f"Ignoring {int(blank.sum())} blank sheet rows")
+    df = df[~blank].copy()
+
+    return df.replace("", None) if blanks_as_none else df
+
+
+def drop_unmapped_columns(df: pandas.DataFrame, model) -> pandas.DataFrame:
+    """Keep only the columns the model actually has.
+
+    The sheet is edited by hand and grows columns that the database does not
+    have, such as a weight recorded in pounds alongside the one in kilograms.
+    Passing one of those to a model is a TypeError, so drop them here rather
+    than letting a new column break the whole load.
+    """
+    mapped = {column.key for column in sqlalchemy.inspect(model).mapper.column_attrs}
+    unmapped = [column for column in df.columns if column not in mapped]
+    if unmapped:
+        logger.debug(
+            f"Ignoring sheet columns that {model.__name__} does not have: "
+            f"{', '.join(unmapped)}"
+        )
+
+    return df.drop(columns=unmapped)
+
+
+def drop_incomplete_workouts(df: pandas.DataFrame) -> pandas.DataFrame:
+    """Drop workout rows that are missing a value the model requires.
+
+    Each one is named by its sheet row so the gap can be found and filled in,
+    rather than the whole migration failing on the first bad cast.
+    """
+    incomplete = df[REQUIRED_WORKOUT_VALUES].isna().any(axis=1)
+    if not incomplete.any():
+        return df
+
+    for row in df[incomplete].to_dict(orient="records"):
+        missing = [c for c in REQUIRED_WORKOUT_VALUES if pandas.isna(row[c])]
+        logger.warning(
+            f"Skipping workouts sheet row {row[SHEET_ROW]}, "
+            f"it has no {', '.join(missing)}"
+        )
+
+    return df[~incomplete].copy()

--- a/src/resolvers/go_heavier/sessions.py
+++ b/src/resolvers/go_heavier/sessions.py
@@ -1,0 +1,121 @@
+import datetime
+from typing import List, Optional
+
+from sqlalchemy import distinct, func, select
+
+from src.config import Config
+from src.db import session
+from src.models.go_heavier import Exercise as DBExercise
+from src.models.go_heavier import Location as DBLocation
+from src.models.go_heavier import Workout as DBWorkout
+from src.schemas.go_heavier.sessions import (
+    ListSessionsRequest,
+    SessionExerciseStats,
+    SessionResponse,
+    SessionSummary,
+)
+
+# A session is every set sharing one workout_time, so the summary of one is a
+# group by over that column. Each session has a single location.
+_SUMMARY_COLUMNS = (
+    DBWorkout.workout_time,
+    DBWorkout.location_id,
+    DBLocation.name.label("location"),
+    func.count(DBWorkout.id).label("sets"),
+    func.count(distinct(DBWorkout.exercise_id)).label("exercises"),
+    func.sum(DBWorkout.repetitions).label("repetitions"),
+    func.sum(DBWorkout.weight_kg * DBWorkout.repetitions).label("volume_kg"),
+    func.max(DBWorkout.weight_kg).label("heaviest_weight_kg"),
+)
+
+
+def _to_summary(row) -> SessionSummary:
+    return SessionSummary(
+        workout_time=row.workout_time,
+        location_id=row.location_id,
+        location=row.location,
+        sets=row.sets,
+        exercises=row.exercises,
+        repetitions=row.repetitions or 0,
+        volume_kg=round(row.volume_kg or 0.0, 2),
+        heaviest_weight_kg=row.heaviest_weight_kg,
+    )
+
+
+def get_sessions(request: ListSessionsRequest) -> List[SessionSummary]:
+    """List sessions, most recent first."""
+    conditions = []
+    if request.location_id:
+        conditions.append(DBWorkout.location_id == request.location_id)
+    if request.exercise_id:
+        # Select the sessions that included the exercise, but still total up
+        # every set in them rather than only that exercise's sets.
+        conditions.append(
+            DBWorkout.workout_time.in_(
+                select(DBWorkout.workout_time).filter(
+                    DBWorkout.exercise_id == request.exercise_id
+                )
+            )
+        )
+    if request.after:
+        conditions.append(DBWorkout.workout_time >= request.after)
+    if request.before:
+        conditions.append(DBWorkout.workout_time <= request.before)
+
+    rows = (
+        session.query(*_SUMMARY_COLUMNS)
+        .join(DBLocation, DBLocation.id == DBWorkout.location_id)
+        .filter(*conditions)
+        .group_by(DBWorkout.workout_time, DBWorkout.location_id, DBLocation.name)
+        .order_by(DBWorkout.workout_time.desc())
+        .limit(Config.DEFAULT_DB_PAGE_SIZE)
+        .offset(request.offset)
+        .all()
+    )
+
+    return [_to_summary(row) for row in rows]
+
+
+def get_session(workout_time: datetime.datetime) -> Optional[SessionResponse]:
+    """Return one session with its per exercise breakdown."""
+    summary = (
+        session.query(*_SUMMARY_COLUMNS)
+        .join(DBLocation, DBLocation.id == DBWorkout.location_id)
+        .filter(DBWorkout.workout_time == workout_time)
+        .group_by(DBWorkout.workout_time, DBWorkout.location_id, DBLocation.name)
+        .first()
+    )
+    if not summary:
+        return None
+
+    by_exercise = (
+        session.query(
+            DBWorkout.exercise_id,
+            DBExercise.name,
+            func.count(DBWorkout.id).label("sets"),
+            func.sum(DBWorkout.repetitions).label("repetitions"),
+            func.sum(DBWorkout.weight_kg * DBWorkout.repetitions).label("volume_kg"),
+            func.max(DBWorkout.weight_kg).label("heaviest_weight_kg"),
+            func.min(DBWorkout.index).label("first_set"),
+        )
+        .join(DBExercise, DBExercise.id == DBWorkout.exercise_id)
+        .filter(DBWorkout.workout_time == workout_time)
+        .group_by(DBWorkout.exercise_id, DBExercise.name)
+        .order_by("first_set", DBExercise.name)
+        .all()
+    )
+
+    return SessionResponse(
+        **_to_summary(summary).model_dump(),
+        by_exercise=[
+            SessionExerciseStats(
+                exercise_id=row.exercise_id,
+                name=row.name,
+                sets=row.sets,
+                repetitions=row.repetitions or 0,
+                volume_kg=round(row.volume_kg or 0.0, 2),
+                heaviest_weight_kg=row.heaviest_weight_kg,
+            )
+            for row in by_exercise
+        ],
+    )

--- a/src/routers/go_heavier/sessions.py
+++ b/src/routers/go_heavier/sessions.py
@@ -1,0 +1,40 @@
+import datetime
+from typing import Annotated, List
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.resolvers.go_heavier import sessions
+from src.schemas.go_heavier.sessions import (
+    ListSessionsRequest,
+    SessionResponse,
+    SessionSummary,
+)
+
+router = APIRouter(prefix="/go-heavier", tags=["sessions"])
+
+
+@router.get("/sessions", response_model=List[SessionSummary])
+async def get_sessions(
+    request: Annotated[ListSessionsRequest, Query()],
+) -> List[SessionSummary]:
+    return sessions.get_sessions(request=request)
+
+
+@router.get("/sessions/{workout_time}", response_model=SessionResponse)
+async def get_session(workout_time: str) -> SessionResponse:
+    try:
+        parsed = datetime.datetime.fromisoformat(workout_time)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail={"detail": "Invalid format for workout time, expected ISO 8601"},
+        )
+    # A session key read off a listing is in UTC, and a bare one is taken as UTC
+    # rather than as the server's local time.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+
+    workout_session = sessions.get_session(workout_time=parsed)
+    if not workout_session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return workout_session

--- a/src/schemas/go_heavier/sessions.py
+++ b/src/schemas/go_heavier/sessions.py
@@ -1,0 +1,94 @@
+"""Schemas for a workout session, the sets sharing one workout_time."""
+
+import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+)
+
+from src.schemas.utils import PaginationParams
+
+
+class ListSessionsRequest(PaginationParams):
+    """Query parameters for listing sessions, most recent first."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    location_id: Optional[UUID] = Field(
+        description="Only list sessions at this location",
+        default=None,
+    )
+    exercise_id: Optional[UUID] = Field(
+        description="Only list sessions that included this exercise. The totals "
+        "still cover the whole session, not just that exercise",
+        default=None,
+    )
+    after: Optional[AwareDatetime] = Field(
+        description="Only list sessions at or after this datetime",
+        default=None,
+    )
+    before: Optional[AwareDatetime] = Field(
+        description="Only list sessions at or before this datetime",
+        default=None,
+    )
+
+
+class _BaseSession(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    workout_time: AwareDatetime = Field(
+        description="When the session took place, the key identifying it"
+    )
+    location_id: UUID = Field(description="Unique identifier for the location")
+    location: str = Field(description="Name of the location")
+    sets: int = Field(description="Number of sets logged in the session")
+    exercises: int = Field(description="Number of different exercises in the session")
+    repetitions: int = Field(description="Total repetitions across the session")
+    volume_kg: float = Field(
+        description="Total weight moved, the sum of weight_kg multiplied by repetitions"
+    )
+    heaviest_weight_kg: float = Field(
+        description="The heaviest single weight lifted in the session"
+    )
+
+    @field_validator("workout_time", mode="before")
+    @classmethod
+    def ensure_timezone_aware(cls, value):
+        """Convert naive datetimes to timezone-aware datetimes (UTC)"""
+        if value is None:
+            return None
+        if isinstance(value, datetime.datetime) and value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value
+
+
+class SessionExerciseStats(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    exercise_id: UUID = Field(description="Unique identifier for the exercise")
+    name: str = Field(description="Name of the exercise")
+    sets: int = Field(description="Number of sets of this exercise in the session")
+    repetitions: int = Field(description="Total repetitions across those sets")
+    volume_kg: float = Field(
+        description="Total weight moved, the sum of weight_kg multiplied by repetitions"
+    )
+    heaviest_weight_kg: float = Field(
+        description="The heaviest single weight lifted for this exercise"
+    )
+
+
+class SessionSummary(_BaseSession):
+    pass
+
+
+class SessionResponse(_BaseSession):
+    by_exercise: List[SessionExerciseStats] = Field(
+        description="Per exercise breakdown, in the order the exercises were performed",
+        default_factory=list,
+    )

--- a/src/schemas/go_heavier/workouts.py
+++ b/src/schemas/go_heavier/workouts.py
@@ -28,7 +28,7 @@ class _BaseWorkout(BaseModel):
         description="The index of the set within the workout session",
         nullable=False,
         gt=0,
-        lt=10,
+        lt=100,
     )
     repetitions: int = Field(
         description="The number of times the workout action was repeated",
@@ -37,9 +37,10 @@ class _BaseWorkout(BaseModel):
         lt=100,
     )
     weight_kg: float = Field(
-        description="The weight used during the workout in kilograms",
+        description="The weight used during the workout in kilograms. Negative "
+        "for an assisted exercise, where the machine takes weight off the lifter",
         nullable=False,
-        ge=0.0,
+        gt=-1000.0,
         lt=1000.0,
     )
     bar_weight_kg: Optional[float] = Field(
@@ -50,9 +51,10 @@ class _BaseWorkout(BaseModel):
         default=None,
     )
     supplementary_weight_kg: Optional[float] = Field(
-        description="The supplementary weight added to the bar during the workout in kilograms",
+        description="The supplementary weight added to the bar during the workout "
+        "in kilograms. Negative when it assists rather than loads the lifter",
         nullable=True,
-        gt=0.0,
+        gt=-100.0,
         lt=100.0,
         default=None,
     )

--- a/tests/test_session_schema.py
+++ b/tests/test_session_schema.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.schemas.go_heavier.sessions import (
+    ListSessionsRequest,
+    SessionExerciseStats,
+    SessionResponse,
+    SessionSummary,
+)
+
+
+def _payload(**overrides) -> dict:
+    payload = {
+        "workout_time": datetime(2026, 8, 20, 21, 20, tzinfo=timezone.utc),
+        "location_id": uuid4(),
+        "location": "The Gym Greenford",
+        "sets": 17,
+        "exercises": 6,
+        "repetitions": 158,
+        "volume_kg": 8069.9,
+        "heaviest_weight_kg": 100.0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestSessionSummary:
+    """Test a session as it appears in the listing."""
+
+    def test_a_naive_workout_time_is_made_timezone_aware(self):
+        """The column is read back naive in places and is assumed UTC."""
+        summary = SessionSummary(**_payload(workout_time=datetime(2026, 8, 20, 21, 20)))
+
+        assert summary.workout_time == datetime(
+            2026, 8, 20, 21, 20, tzinfo=timezone.utc
+        )
+
+    def test_an_aware_workout_time_is_left_alone(self):
+        workout_time = datetime(2026, 8, 20, 21, 20, tzinfo=timezone.utc)
+
+        assert SessionSummary(**_payload()).workout_time == workout_time
+
+    def test_an_assisted_session_can_be_heaviest_negative(self):
+        """A session of only assisted work has a negative heaviest weight."""
+        summary = SessionSummary(**_payload(heaviest_weight_kg=-14.0))
+
+        assert summary.heaviest_weight_kg == -14.0
+
+
+class TestSessionResponse:
+    """Test a single session with its breakdown."""
+
+    def test_the_breakdown_is_parsed(self):
+        exercise_id = uuid4()
+        response = SessionResponse(
+            **_payload(),
+            by_exercise=[
+                {
+                    "exercise_id": exercise_id,
+                    "name": "Cable Fly",
+                    "sets": 3,
+                    "repetitions": 25,
+                    "volume_kg": 327.9,
+                    "heaviest_weight_kg": 14.7,
+                }
+            ],
+        )
+
+        assert response.by_exercise == [
+            SessionExerciseStats(
+                exercise_id=exercise_id,
+                name="Cable Fly",
+                sets=3,
+                repetitions=25,
+                volume_kg=327.9,
+                heaviest_weight_kg=14.7,
+            )
+        ]
+
+    def test_the_breakdown_defaults_to_empty(self):
+        assert SessionResponse(**_payload()).by_exercise == []
+
+
+class TestListSessionsRequest:
+    """Test the query parameters for listing sessions."""
+
+    def test_defaults(self):
+        request = ListSessionsRequest()
+
+        assert request.page == 1
+        assert request.location_id is None
+        assert request.exercise_id is None
+        assert request.after is None
+        assert request.before is None
+
+    def test_pages_are_offset_by_the_page_size(self):
+        assert ListSessionsRequest(page=1).offset == 0
+        assert ListSessionsRequest(page=3).offset > 0
+
+    @pytest.mark.parametrize("page", [0, -1])
+    def test_the_page_must_be_positive(self, page: int):
+        with pytest.raises(ValidationError):
+            ListSessionsRequest(page=page)
+
+    def test_naive_bounds_are_rejected(self):
+        """Bounds must be timezone aware so they can be compared to workout_time."""
+        with pytest.raises(ValidationError):
+            ListSessionsRequest(after=datetime(2026, 8, 1, 0, 0))
+
+    def test_malformed_id_filters_are_rejected(self):
+        with pytest.raises(ValidationError):
+            ListSessionsRequest(exercise_id="not-a-uuid")

--- a/tests/test_sheet_frames.py
+++ b/tests/test_sheet_frames.py
@@ -1,0 +1,134 @@
+import logging
+
+import pandas
+import pytest
+
+from src.migration_utils.sheet_frames import (
+    SHEET_ROW,
+    drop_incomplete_workouts,
+    drop_unmapped_columns,
+    to_frame,
+)
+from src.models.go_heavier import Workout
+
+HEADER = ["id", "name", "weight_kg", "weight_lb"]
+
+
+class TestToFrame:
+    """Test building a frame from raw sheet values."""
+
+    def test_sheet_rows_are_numbered_from_two(self):
+        """Row 1 is the header, so the first record is row 2 in the sheet."""
+        df = to_frame([HEADER, ["a", "Bench", "20", ""], ["b", "Squat", "40", ""]])
+
+        assert list(df[SHEET_ROW]) == [2, 3]
+
+    def test_blank_rows_are_dropped(self):
+        """A spreadsheet accumulates blank spacer and trailing rows."""
+        df = to_frame(
+            [
+                HEADER,
+                ["a", "Bench", "20", ""],
+                ["", "", "", ""],
+                ["b", "Squat", "40", ""],
+                ["  ", "", " ", ""],
+            ]
+        )
+
+        assert list(df[SHEET_ROW]) == [2, 4]
+
+    def test_a_row_with_only_an_id_is_kept(self):
+        """Only a completely empty row is structural; a stray id is a real gap."""
+        df = to_frame([HEADER, ["a", "", "", ""]])
+
+        assert list(df[SHEET_ROW]) == [2]
+
+    def test_blanks_are_left_alone_by_default(self):
+        """A caller casting with astype(str) would turn None into "None"."""
+        df = to_frame([HEADER, ["a", "", "20", ""]])
+
+        assert df["name"].iloc[0] == ""
+
+    def test_blanks_become_missing_when_asked(self):
+        """Blank becomes a pandas missing value, which ffill and isna understand."""
+        df = to_frame([HEADER, ["a", "", "20", ""]], blanks_as_none=True)
+
+        assert pandas.isna(df["name"].iloc[0])
+
+    def test_an_empty_sheet_gives_an_empty_frame(self):
+        assert to_frame([HEADER]).empty
+
+
+class TestDropUnmappedColumns:
+    """Test discarding sheet columns the model does not have."""
+
+    def test_unmapped_columns_are_dropped(self):
+        """The sheet grows columns, such as a weight recorded in pounds."""
+        df = pandas.DataFrame(
+            [{"weight_kg": 20.0, "weight_lb": 44.0, SHEET_ROW: 2, "repetitions": 10}]
+        )
+
+        remaining = drop_unmapped_columns(df, Workout)
+
+        assert set(remaining.columns) == {"weight_kg", "repetitions"}
+
+    def test_mapped_columns_are_kept_in_place(self):
+        df = pandas.DataFrame([{"weight_kg": 20.0, "repetitions": 10}])
+
+        assert list(drop_unmapped_columns(df, Workout).columns) == [
+            "weight_kg",
+            "repetitions",
+        ]
+
+
+class TestDropIncompleteWorkouts:
+    """Test rejecting workout rows that are missing a required value."""
+
+    @staticmethod
+    def _frame(*overrides) -> pandas.DataFrame:
+        rows = []
+        for i, override in enumerate(overrides):
+            row = {
+                "location": "gym",
+                "exercise": "bench",
+                "workout_time": "2026-08-07",
+                "index": 1.0,
+                "repetitions": 10.0,
+                "weight_kg": 20.0,
+                SHEET_ROW: i + 2,
+            }
+            row.update(override)
+            rows.append(row)
+        return pandas.DataFrame(rows)
+
+    def test_complete_rows_are_kept(self):
+        df = self._frame({}, {})
+
+        assert len(drop_incomplete_workouts(df)) == 2
+
+    @pytest.mark.parametrize(
+        "column",
+        ["location", "exercise", "workout_time", "index", "repetitions", "weight_kg"],
+    )
+    def test_a_row_missing_any_required_value_is_dropped(self, column: str):
+        df = self._frame({}, {column: None})
+
+        remaining = drop_incomplete_workouts(df)
+
+        assert list(remaining[SHEET_ROW]) == [2]
+
+    def test_the_skipped_row_is_named_in_the_warning(self, caplog):
+        """The sheet row is logged so the gap can be found and filled in."""
+        df = self._frame({}, {"weight_kg": None, "repetitions": None})
+
+        with caplog.at_level(logging.WARNING):
+            drop_incomplete_workouts(df)
+
+        assert "sheet row 3" in caplog.text
+        assert "repetitions, weight_kg" in caplog.text
+
+    def test_a_zero_weight_is_not_treated_as_missing(self):
+        """Bodyweight exercises are logged at 0kg and are perfectly valid."""
+        df = self._frame({"weight_kg": 0.0})
+
+        assert len(drop_incomplete_workouts(df)) == 1

--- a/tests/test_workout_schema_validation.py
+++ b/tests/test_workout_schema_validation.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from src.schemas.go_heavier.workouts import WorkoutResponse, _BaseWorkout
 
@@ -297,8 +298,8 @@ class TestBaseWorkoutValidation:
 class TestValidationErrors:
     """Test that proper validation errors are raised for invalid data."""
 
-    def test_invalid_weight_kg_raises_error(self):
-        """Test that invalid weight_kg values raise validation errors."""
+    def test_out_of_range_weight_kg_raises_error(self):
+        """A negative weight is an assisted exercise; only the outer bound is invalid."""
         with pytest.raises(Exception):  # Pydantic ValidationError
             WorkoutResponse(
                 id=uuid4(),
@@ -307,7 +308,7 @@ class TestValidationErrors:
                 workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
                 index=1,
                 repetitions=10,
-                weight_kg=-5.0,  # Invalid: must be > 0
+                weight_kg=-1000.0,  # Invalid: must be > -1000
                 bar_weight_kg=20.0,
                 supplementary_weight_kg=5.0,
                 created_at=datetime(2026, 6, 3, 0, 47, 31, tzinfo=timezone.utc),
@@ -364,3 +365,54 @@ class TestValidationErrors:
                 created_at=datetime(2026, 6, 3, 0, 47, 31, tzinfo=timezone.utc),
                 updated_at=datetime(2026, 6, 3, 0, 47, 31, tzinfo=timezone.utc),
             )
+
+
+class TestAssistedWeights:
+    """Test the weights of an assisted exercise, where the machine takes load off."""
+
+    @staticmethod
+    def _workout(**overrides) -> _BaseWorkout:
+        payload = {
+            "location_id": uuid4(),
+            "exercise_id": uuid4(),
+            "workout_time": datetime(2026, 8, 7, 14, 30, tzinfo=timezone.utc),
+            "index": 1,
+            "repetitions": 10,
+            "weight_kg": 50.0,
+        }
+        payload.update(overrides)
+        return _BaseWorkout(**payload)
+
+    @pytest.mark.parametrize("weight_kg", [-59.0, -14.0, -0.5])
+    def test_negative_weight_is_accepted(self, weight_kg: float):
+        """An assisted pull up is logged as the weight the machine takes off."""
+        assert self._workout(weight_kg=weight_kg).weight_kg == weight_kg
+
+    def test_negative_supplementary_weight_is_accepted(self):
+        assert self._workout(supplementary_weight_kg=-5.0).supplementary_weight_kg == (
+            -5.0
+        )
+
+    @pytest.mark.parametrize("weight_kg", [-1000.0, 1000.0])
+    def test_the_outer_bounds_are_still_enforced(self, weight_kg: float):
+        with pytest.raises(ValidationError):
+            self._workout(weight_kg=weight_kg)
+
+    def test_a_bar_cannot_weigh_less_than_nothing(self):
+        """Only the lifted and supplementary weights can assist."""
+        with pytest.raises(ValidationError):
+            self._workout(bar_weight_kg=-5.0)
+
+
+class TestSetIndex:
+    """Test the index of a set within a session."""
+
+    @pytest.mark.parametrize("index", [1, 12, 99])
+    def test_long_sessions_are_accepted(self, index: int):
+        """Sessions of more than nine sets of one exercise do occur."""
+        assert TestAssistedWeights._workout(index=index).index == index
+
+    @pytest.mark.parametrize("index", [0, -1, 100])
+    def test_the_bounds_are_still_enforced(self, index: int):
+        with pytest.raises(ValidationError):
+            TestAssistedWeights._workout(index=index)


### PR DESCRIPTION
Three commits that missed #16 — they were finished but held back from the push, so main merged without them. The migration endpoint on main still fails on the full sheet until this lands.

## Sheet row validation

Running the migration over the whole sheet failed with `cannot convert float NaN to integer`, and behind that with `'weight_lb' is an invalid keyword argument for Workout`. Three separate problems in the data, each taking the whole load down:

| sheet rows | problem | handling |
| --- | --- | --- |
| 592 | completely blank spacer row | dropped |
| 539, 540, 541 | Cable Fly, `weight_kg` empty | skipped, warned |
| 997 | has an id, nothing else | skipped, warned |
| — | sheet has a `weight_lb` column the model lacks | column dropped |

Blank rows are dropped **before** the forward fill. Left in place, a spacer row inherits the session above it and shifts the set numbering of every row below it, so this also fixes a silent correctness bug.

Rows missing a required value are skipped with a warning naming the sheet row and columns, so a gap can be found rather than guessed at:

```
WARNING Skipping workouts sheet row 539, it has no weight_kg
WARNING Skipping workouts sheet row 997, it has no repetitions, weight_kg
```

On the current sheet this loads 1237 of 1242 rows.

## Assisted weights and long sessions

A negative weight records an assisted exercise, where the machine takes load off the lifter. These were response validation errors, not bad input — the rows were already in the database and the endpoint returned a 500 while serialising them. I checked every constrained field against the real data rather than fixing them one at a time:

| field | data range | old bound | action |
| --- | --- | --- | --- |
| `weight_kg` | −59 … 134 | `ge=0` | → `gt=-1000` |
| `supplementary_weight_kg` | −5 … | `gt=0` | → `gt=-100` |
| `index` | 1 … 12 | `lt=10` | → `lt=100` |
| `repetitions` | 1 … 62 | `lt=100` | unchanged |
| `bar_weight_kg` | 0 … | `gt=0` | unchanged |

`bar_weight_kg` stays positive-only: a bar has mass whichever exercise it is used for, and the assisted sets carry none. The `index` change is unrelated to assistance — there are twelve-set Calf Extension sessions and the schema capped a session at nine sets of one exercise.

An existing test asserted `weight_kg=-5.0` must be rejected; it encoded the rule being changed, so it now covers the outer bound rather than losing the coverage.

## Session endpoints

A session — every set sharing one `workout_time` — was only implicit in the data.

```bash
curl "localhost:8000/go-heavier/sessions" | jq
curl "localhost:8000/go-heavier/sessions/2026-08-20T21:20:00Z" | jq
```

Filtering the listing by exercise selects the sessions that included it while still totalling every set in them, rather than only that exercise's sets. A time with no offset is read as UTC; anything unparseable is a 400, matching the other routes taking a key in the path.

## Testing

- 136 tests pass; ruff, ruff format and isort clean.
- Verified end to end against the real sheet: 1242 rows → 1237 loaded, and the migration endpoint that returned 500 now returns 200. Ran it against a local database: 795 → 1258 workouts, zero NaN weights, zero `"None"` notes.
- All 20 assisted sets (Assisted Pull Ups, down to −59 kg) serialise, and all 29 pages of `GET /workouts` return 200.
- Session totals cross-check against `/workouts/stats` exactly: 1261 sets, 63 sessions. Pagination splits 50 + 13 with no overlap.

## Notes for review

- **`workout_time` as the session key is provisional.** Follow-up work will make sessions a real table with a UUID, at which point `/sessions/{id}` changes shape. Raising this now so the validation fixes are not blocked behind that.
- **`ListWorkoutsRequest` is broken on main** — `exercise_id` and `location_id` are typed `UUID` but carry `min_length`/`max_length`, which pydantic cannot apply to a UUID, so any filtered `GET /workouts` raises `TypeError`. Not touched here.
- **NaN is stored** for `bar_weight_kg` and `supplementary_weight_kg`: the loader's `astype(float)` writes NaN rather than NULL for blank cells. Invisible today because `convert_nan_to_none` converts it on the way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)