### PR TITLE
Give a session its own table, and endpoints to manage one

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ curl "localhost:8000/go-heavier/sessions?exercise_id=$EXERCISE_ID" | jq
 curl "localhost:8000/go-heavier/sessions/$SESSION_ID" | jq
 ```
 
+Deleting a session deletes every set logged against it. The sets belong to the
+session and carry neither a location nor a time of their own, so leaving them
+would leave rows that cannot be placed.
+
+```bash
+curl -X DELETE "localhost:8000/go-heavier/sessions/$SESSION_ID"
+```
+
 | query param | default | description |
 | --- | --- | --- |
 | `location_id` | none | only list sessions at this location |

--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ sheet load merge onto the existing sessions instead of inserting duplicates.
 Correcting a session's time in the sheet therefore produces a new id, leaving
 the old session behind to be cleaned up.
 
+### Session stats
+
+`GET /go-heavier/sessions/stats` aggregates across sessions, where
+`/sessions/{session_id}` aggregates within one. Averages are taken per session
+rather than per set, so they answer what a typical visit looks like.
+
+```bash
+curl "localhost:8000/go-heavier/sessions/stats" | jq
+
+curl "localhost:8000/go-heavier/sessions/stats?location_id=$LOCATION_ID&after=2026-01-01T00:00:00Z" | jq
+```
+
+| query param | default | description |
+| --- | --- | --- |
+| `location_id` | none | only count sessions at this location |
+| `exercise_id` | none | only count sessions that included this exercise |
+| `after` / `before` | none | inclusive `workout_time` bounds |
+
+`average_days_between_sessions` and `longest_gap_days` are null rather than zero
+when there are fewer than two sessions to measure between. `by_weekday` is in UK
+local time, Monday first, and omits days with no sessions.
+
+Note that the route is declared before `/sessions/{session_id}` in the router, so
+that `stats` is not matched as a session id.
+
 ### Loading data from the Google Sheet
 
 `POST /go-heavier/migrations` runs the same load the data migrations run, upserting

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ time live on the session rather than being repeated on all of its sets.
 breakdown, ordered by the set each exercise started on.
 
 ```bash
+# create a session, then log sets against it
+curl -X POST localhost:8000/go-heavier/sessions \
+  -H 'Content-Type: application/json' \
+  -d '{"location_id": "'$LOCATION_ID'", "workout_time": "2026-09-01T18:00:00Z"}' | jq
+
 curl "localhost:8000/go-heavier/sessions" | jq
 
 # sessions that included one exercise, though the totals still cover the whole session
@@ -151,6 +156,11 @@ curl "localhost:8000/go-heavier/sessions/$SESSION_ID" | jq
 | `exercise_id` | none | only list sessions that included this exercise |
 | `after` / `before` | none | inclusive `workout_time` bounds |
 | `page` | `1` | pages of `DEFAULT_DB_PAGE_SIZE` sessions |
+
+Creating a session derives its id from the location and the time in exactly
+the way the sheet load does, so the two converge on one row instead of competing
+for the unique constraint over that pair. Creating the same one twice is a `409`
+carrying the existing id.
 
 The sheet has no session id, so one is derived from the location and the time
 with a `uuid5`. That keeps it identical on every run, which is what lets the

--- a/README.md
+++ b/README.md
@@ -128,9 +128,12 @@ that `stats` is not matched as a workout id.
 
 ### Sessions
 
-A session is every set sharing one `workout_time`, which until now was only
-implicit in the data. `GET /go-heavier/sessions` lists them most recent first,
-and `GET /go-heavier/sessions/{workout_time}` returns one with a per exercise
+A session is one visit to a gym, and owns every set performed while there. It is
+a table of its own: `workouts` carries a `session_id`, and the location and the
+time live on the session rather than being repeated on all of its sets.
+
+`GET /go-heavier/sessions` lists them most recent first, and
+`GET /go-heavier/sessions/{session_id}` returns one with a per exercise
 breakdown, ordered by the set each exercise started on.
 
 ```bash
@@ -139,7 +142,7 @@ curl "localhost:8000/go-heavier/sessions" | jq
 # sessions that included one exercise, though the totals still cover the whole session
 curl "localhost:8000/go-heavier/sessions?exercise_id=$EXERCISE_ID" | jq
 
-curl "localhost:8000/go-heavier/sessions/2026-08-20T21:20:00Z" | jq
+curl "localhost:8000/go-heavier/sessions/$SESSION_ID" | jq
 ```
 
 | query param | default | description |
@@ -149,14 +152,18 @@ curl "localhost:8000/go-heavier/sessions/2026-08-20T21:20:00Z" | jq
 | `after` / `before` | none | inclusive `workout_time` bounds |
 | `page` | `1` | pages of `DEFAULT_DB_PAGE_SIZE` sessions |
 
-The path parameter is the session's `workout_time` in ISO 8601, exactly as the
-listing returns it. A time with no offset is read as UTC.
+The sheet has no session id, so one is derived from the location and the time
+with a `uuid5`. That keeps it identical on every run, which is what lets the
+sheet load merge onto the existing sessions instead of inserting duplicates.
+Correcting a session's time in the sheet therefore produces a new id, leaving
+the old session behind to be cleaned up.
 
 ### Loading data from the Google Sheet
 
 `POST /go-heavier/migrations` runs the same load the data migrations run, upserting
 rows from the Google Sheet into the database. Tables are always migrated in
-dependency order (locations, exercises, then workouts) regardless of the order given.
+dependency order (locations, exercises, sessions, then workouts) regardless of
+the order given.
 
 ```bash
 # everything
@@ -176,7 +183,7 @@ curl -X POST localhost:8000/go-heavier/migrations \
 
 | field | default | description |
 | --- | --- | --- |
-| `tables` | all | any of `locations`, `exercises`, `workouts` |
+| `tables` | all | any of `locations`, `exercises`, `sessions`, `workouts` |
 | `dry_run` | `false` | parse the sheet but write nothing |
 | `workouts_after` / `workouts_before` | none | inclusive `workout_time` bounds |
 | `workouts_row_start` / `workouts_row_end` | whole sheet | sheet row bounds, as used by the data migrations |

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -7,6 +7,7 @@ from sqlalchemy import engine_from_config, pool
 from src.models import metadata
 from src.models.go_heavier import Exercise  # noqa: F401
 from src.models.go_heavier import Location  # noqa: F401
+from src.models.go_heavier import Session  # noqa: F401
 from src.models.go_heavier import Workout  # noqa: F401
 from src.models.user import User  # noqa: F401
 

--- a/migrations/versions/2026_08_22_1838-5679283b9822_move_location_and_time_onto_a_session.py
+++ b/migrations/versions/2026_08_22_1838-5679283b9822_move_location_and_time_onto_a_session.py
@@ -1,0 +1,133 @@
+"""move location and time onto a session
+
+Revision ID: 5679283b9822
+Revises: 4c0deee26f71
+Create Date: 2026-08-22 18:38:16.947942
+
+"""
+
+import datetime
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from src.migration_utils.session_ids import session_id_for
+
+# revision identifiers, used by Alembic.
+revision: str = "5679283b9822"
+down_revision: Union[str, Sequence[str], None] = "4c0deee26f71"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Give a session its own row, rather than repeating it on every set."""
+    op.create_table(
+        "sessions",
+        sa.Column(
+            "id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("location_id", sa.Uuid(), nullable=False),
+        sa.Column("workout_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["location_id"],
+            ["locations.id"],
+            name=op.f("fk_sessions_location_id_locations"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_sessions")),
+        sa.UniqueConstraint(
+            "location_id", "workout_time", name=op.f("uq_sessions_location_id")
+        ),
+    )
+    op.add_column("workouts", sa.Column("session_id", sa.Uuid(), nullable=True))
+
+    _backfill_sessions()
+
+    op.alter_column("workouts", "session_id", nullable=False)
+    op.create_foreign_key(
+        op.f("fk_workouts_session_id_sessions"),
+        "workouts",
+        "sessions",
+        ["session_id"],
+        ["id"],
+    )
+    op.drop_constraint(op.f("fk_workouts_location_id_locations"), "workouts")
+    op.drop_column("workouts", "location_id")
+    op.drop_column("workouts", "workout_time")
+    # Never populated in any environment
+    op.drop_column("workouts", "exercise_index")
+
+
+def _backfill_sessions() -> None:
+    """Create one session per location and time, and point the sets at it.
+
+    The ids are derived rather than random so that re-running the sheet load
+    merges onto these same rows instead of inserting duplicates.
+    """
+    connection = op.get_bind()
+    existing = connection.execute(
+        sa.text(
+            "select distinct location_id, workout_time from workouts "
+            "order by workout_time"
+        )
+    ).all()
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    for location_id, workout_time in existing:
+        session_id = session_id_for(location_id=location_id, workout_time=workout_time)
+        connection.execute(
+            sa.text(
+                "insert into sessions "
+                "(id, location_id, workout_time, created_at, updated_at) "
+                "values (:id, :location_id, :workout_time, :now, :now)"
+            ),
+            {
+                "id": session_id,
+                "location_id": location_id,
+                "workout_time": workout_time,
+                "now": now,
+            },
+        )
+        connection.execute(
+            sa.text(
+                "update workouts set session_id = :id "
+                "where location_id = :location_id and workout_time = :workout_time"
+            ),
+            {
+                "id": session_id,
+                "location_id": location_id,
+                "workout_time": workout_time,
+            },
+        )
+
+    print(f"Created {len(existing)} sessions")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column("workouts", sa.Column("exercise_index", sa.Integer(), nullable=True))
+    op.add_column("workouts", sa.Column("location_id", sa.Uuid(), nullable=True))
+    op.add_column(
+        "workouts", sa.Column("workout_time", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.execute(
+        "update workouts set location_id = sessions.location_id, "
+        "workout_time = sessions.workout_time "
+        "from sessions where sessions.id = workouts.session_id"
+    )
+    op.alter_column("workouts", "location_id", nullable=False)
+    op.alter_column("workouts", "workout_time", nullable=False)
+    op.create_foreign_key(
+        op.f("fk_workouts_location_id_locations"),
+        "workouts",
+        "locations",
+        ["location_id"],
+        ["id"],
+    )
+
+    op.drop_constraint(op.f("fk_workouts_session_id_sessions"), "workouts")
+    op.drop_column("workouts", "session_id")
+    op.drop_table("sessions")

--- a/src/migration_utils/google_sheets.py
+++ b/src/migration_utils/google_sheets.py
@@ -164,7 +164,10 @@ def _workout_frame(
         for location, workout_time in zip(df["location"], df["workout_time"])
     ]
 
-    return df
+    # Named for the model rather than the sheet. Without this the column is
+    # dropped as unmapped and the attribute is never set, which merge() would
+    # quietly leave at whatever the database already held.
+    return df.rename({"exercise": "exercise_id"}, axis=1)
 
 
 def load_sessions_from_sheet(

--- a/src/migration_utils/google_sheets.py
+++ b/src/migration_utils/google_sheets.py
@@ -11,12 +11,13 @@ from src.migration_utils.datetime_parsing import (
     clean_datetime_string,
     parse_sheet_datetime,
 )
+from src.migration_utils.session_ids import session_id_for
 from src.migration_utils.sheet_frames import (
     drop_incomplete_workouts,
     drop_unmapped_columns,
     to_frame,
 )
-from src.models.go_heavier import Exercise, Location, Workout
+from src.models.go_heavier import Exercise, Location, Session, Workout
 
 
 def _get_worksheet(
@@ -113,27 +114,21 @@ def load_exercises_from_sheet(cfg: Config = Config()) -> List[Exercise]:
     return exercises
 
 
-def load_workouts_from_sheet(
-    cfg: Config = Config(),
-    range_start: int = 0,
-    range_end: Optional[int] = None,
-    after: Optional[datetime.datetime] = None,
-    before: Optional[datetime.datetime] = None,
-) -> List[Workout]:
-    """Load workouts from the sheet.
+def _workout_frame(
+    cfg: Config,
+    range_start: int,
+    range_end: Optional[int],
+    after: Optional[datetime.datetime],
+    before: Optional[datetime.datetime],
+) -> pandas.DataFrame:
+    """The workouts sheet, forward filled, narrowed and validated.
 
-    ``range_start``/``range_end`` slice the sheet rows the same way as the raw
-    sheet values, so ``range_end`` counts the header row. ``after``/``before``
-    filter on the workout time. Both are applied after the forward fill so that
-    a narrowed range still inherits the location, exercise and time carried down
-    from the rows above it, and before the remaining columns are parsed so that
-    rows outside the range cannot fail the whole load.
+    Both the sessions and the sets are built from this, so that they cannot
+    disagree about which rows are in range.
     """
     locations_mapping = get_locations_mapping(cfg=cfg)
     exercise_mapping = get_exercises_mapping(cfg=cfg)
-    workouts_sheet = get_workouts(cfg=cfg)
-    workouts: List[Workout] = []
-    data = workouts_sheet.get_all_values()
+    data = get_workouts(cfg=cfg).get_all_values()
 
     df = to_frame(data, blanks_as_none=True)
     df["location"] = df["location"].map(locations_mapping)
@@ -159,7 +154,62 @@ def load_workouts_from_sheet(
         df = df[df["workout_time"] >= after]
     if before is not None:
         df = df[df["workout_time"] <= before]
+
     df = drop_incomplete_workouts(df.copy())
+
+    # The sheet has no session id, so derive a stable one from the pair that
+    # identifies a session. The same pair gives the same id on every run.
+    df["session_id"] = [
+        session_id_for(location_id=location, workout_time=workout_time)
+        for location, workout_time in zip(df["location"], df["workout_time"])
+    ]
+
+    return df
+
+
+def load_sessions_from_sheet(
+    cfg: Config = Config(),
+    range_start: int = 0,
+    range_end: Optional[int] = None,
+    after: Optional[datetime.datetime] = None,
+    before: Optional[datetime.datetime] = None,
+) -> List[Session]:
+    """One session per location and time in the workouts sheet."""
+    df = _workout_frame(cfg, range_start, range_end, after, before)
+
+    sessions_frame = df[["session_id", "location", "workout_time"]].drop_duplicates(
+        subset="session_id"
+    )
+
+    now = pendulum.now("UTC")
+    return [
+        Session(
+            id=row["session_id"],
+            location_id=row["location"],
+            workout_time=row["workout_time"],
+            created_at=now,
+            updated_at=now,
+        )
+        for row in sessions_frame.to_dict(orient="records")
+    ]
+
+
+def load_workouts_from_sheet(
+    cfg: Config = Config(),
+    range_start: int = 0,
+    range_end: Optional[int] = None,
+    after: Optional[datetime.datetime] = None,
+    before: Optional[datetime.datetime] = None,
+) -> List[Workout]:
+    """Load the sets from the sheet.
+
+    ``range_start``/``range_end`` slice the sheet rows the same way as the raw
+    sheet values, so ``range_end`` counts the header row. ``after``/``before``
+    filter on the workout time. The sessions these sets belong to come from
+    ``load_sessions_from_sheet`` and must be merged first.
+    """
+    df = _workout_frame(cfg, range_start, range_end, after, before)
+    workouts: List[Workout] = []
 
     df["index"] = df["index"].astype(int)
     df["weight_kg"] = df["weight_kg"].astype(float)
@@ -178,7 +228,6 @@ def load_workouts_from_sheet(
     df["created_at"] = pendulum.now("UTC")
     df["updated_at"] = pendulum.now("UTC")
 
-    df = df.rename({"location": "location_id", "exercise": "exercise_id"}, axis=1)
     df = drop_unmapped_columns(df, Workout)
 
     for row in df.to_dict(orient="records"):

--- a/src/migration_utils/session_ids.py
+++ b/src/migration_utils/session_ids.py
@@ -1,0 +1,37 @@
+"""Deterministic identity for a workout session.
+
+The sheet has no session id, so one is derived from the location and the time.
+The alembic backfill and the sheet loader both use this, and they must agree:
+a random id would make every re-run of the load insert a duplicate session
+rather than merging onto the existing one.
+
+Kept free of any database or config import so that it stays unit testable.
+"""
+
+import datetime
+import uuid
+
+# uuid5(NAMESPACE_DNS, "go-heavier.thesammy2010.com/sessions"), written out so
+# that it can never drift with a change to how it was derived.
+SESSION_NAMESPACE = uuid.UUID("f6c5586a-21de-56bb-94ca-69b75e100a62")
+
+
+def session_key(location_id: uuid.UUID, workout_time: datetime.datetime) -> str:
+    """The string a session's id is derived from.
+
+    The time is normalised to UTC and truncated to the second so that the same
+    session cannot produce two keys through a differing offset or a stray
+    microsecond.
+    """
+    if workout_time.tzinfo is None:
+        workout_time = workout_time.replace(tzinfo=datetime.timezone.utc)
+    utc = workout_time.astimezone(datetime.timezone.utc)
+
+    return f"{location_id}|{utc.strftime('%Y-%m-%dT%H:%M:%S')}Z"
+
+
+def session_id_for(
+    location_id: uuid.UUID, workout_time: datetime.datetime
+) -> uuid.UUID:
+    """The id of the session at this location and time, the same on every run."""
+    return uuid.uuid5(SESSION_NAMESPACE, session_key(location_id, workout_time))

--- a/src/models/go_heavier/__init__.py
+++ b/src/models/go_heavier/__init__.py
@@ -1,3 +1,4 @@
 from src.models.go_heavier.exercise import Exercise  # noqa: F401
 from src.models.go_heavier.location import Location  # noqa: F401
+from src.models.go_heavier.session import Session  # noqa: F401
 from src.models.go_heavier.workout import Workout  # noqa: F401

--- a/src/models/go_heavier/session.py
+++ b/src/models/go_heavier/session.py
@@ -1,0 +1,39 @@
+import datetime
+import uuid
+
+import pendulum
+from sqlalchemy import DateTime, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql.schema import ForeignKey
+
+from src.models import Base
+
+
+class Session(Base):
+    """A single visit to a gym, holding every set performed while there."""
+
+    __tablename__ = "sessions"
+    __table_args__ = (UniqueConstraint("location_id", "workout_time"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, server_default=func.gen_random_uuid(), nullable=False
+    )
+    location_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("locations.id"), nullable=False
+    )
+    workout_time: Mapped[pendulum.DateTime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(), nullable=False, default=datetime.datetime.now
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(),
+        nullable=True,
+        default=datetime.datetime.now,
+        onupdate=datetime.datetime.now,
+    )
+
+    def __repr__(self) -> str:
+        return f"<Session(id={self.id}, time={self.workout_time})>"

--- a/src/models/go_heavier/workout.py
+++ b/src/models/go_heavier/workout.py
@@ -2,7 +2,6 @@ import datetime
 import uuid
 from typing import Optional
 
-import pendulum
 from sqlalchemy import DateTime, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql.schema import ForeignKey
@@ -16,15 +15,11 @@ class Workout(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         primary_key=True, server_default=func.gen_random_uuid(), nullable=False
     )
-    location_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("locations.id"), nullable=False
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sessions.id"), nullable=False
     )
     exercise_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("exercises.id"), nullable=False
-    )
-    exercise_index: Mapped[int] = mapped_column(nullable=True)
-    workout_time: Mapped[pendulum.DateTime] = mapped_column(
-        DateTime(timezone=True), nullable=False
     )
     index: Mapped[int] = mapped_column(nullable=False)
     repetitions: Mapped[int] = mapped_column(nullable=False)

--- a/src/resolvers/go_heavier/exercises.py
+++ b/src/resolvers/go_heavier/exercises.py
@@ -7,6 +7,7 @@ from sqlalchemy import desc, distinct, func
 from src.db import session
 from src.models.go_heavier.exercise import Exercise as DBExercise
 from src.models.go_heavier.location import Location as DBLocation
+from src.models.go_heavier.session import Session as DBSession
 from src.models.go_heavier.workout import Workout as DBWorkout
 from src.schemas.go_heavier.exercise_stats import (
     ExerciseStatsRequest,
@@ -81,9 +82,9 @@ def get_exercise_stats(
 
     conditions = [DBWorkout.exercise_id == exercise_id]
     if request.after:
-        conditions.append(DBWorkout.workout_time >= request.after)
+        conditions.append(DBSession.workout_time >= request.after)
     if request.before:
-        conditions.append(DBWorkout.workout_time <= request.before)
+        conditions.append(DBSession.workout_time <= request.before)
 
     volume = func.sum(DBWorkout.weight_kg * DBWorkout.repetitions)
     (
@@ -97,31 +98,33 @@ def get_exercise_stats(
         distinct_locations,
     ) = (
         session.query(
-            func.count(distinct(DBWorkout.workout_time)),
+            func.count(distinct(DBWorkout.session_id)),
             func.count(DBWorkout.id),
             func.sum(DBWorkout.repetitions),
             volume,
             func.max(DBWorkout.weight_kg),
-            func.min(DBWorkout.workout_time),
-            func.max(DBWorkout.workout_time),
-            func.count(distinct(DBWorkout.location_id)),
+            func.min(DBSession.workout_time),
+            func.max(DBSession.workout_time),
+            func.count(distinct(DBSession.location_id)),
         )
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .filter(*conditions)
         .one()
     )
 
     top_locations = (
         session.query(
-            DBWorkout.location_id,
+            DBSession.location_id,
             DBLocation.name,
-            func.count(distinct(DBWorkout.workout_time)).label("sessions"),
+            func.count(distinct(DBWorkout.session_id)).label("sessions"),
             func.count(DBWorkout.id).label("sets"),
             func.sum(DBWorkout.repetitions).label("repetitions"),
             volume.label("volume_kg"),
         )
-        .join(DBLocation, DBLocation.id == DBWorkout.location_id)
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
+        .join(DBLocation, DBLocation.id == DBSession.location_id)
         .filter(*conditions)
-        .group_by(DBWorkout.location_id, DBLocation.name)
+        .group_by(DBSession.location_id, DBLocation.name)
         .order_by(desc("sets"), DBLocation.name)
         .limit(request.top_locations)
         .all()

--- a/src/resolvers/go_heavier/locations.py
+++ b/src/resolvers/go_heavier/locations.py
@@ -8,6 +8,7 @@ from sqlalchemy import desc, distinct, func
 from src.db import session
 from src.models.go_heavier.exercise import Exercise as DBExercise
 from src.models.go_heavier.location import Location as DBLocation
+from src.models.go_heavier.session import Session as DBSession
 from src.models.go_heavier.workout import Workout as DBWorkout
 from src.schemas.go_heavier.location_stats import (
     ExerciseStats,
@@ -82,11 +83,11 @@ def get_location_stats(
     if not location:
         return None
 
-    conditions = [DBWorkout.location_id == location_id]
+    conditions = [DBSession.location_id == location_id]
     if request.after:
-        conditions.append(DBWorkout.workout_time >= request.after)
+        conditions.append(DBSession.workout_time >= request.after)
     if request.before:
-        conditions.append(DBWorkout.workout_time <= request.before)
+        conditions.append(DBSession.workout_time <= request.before)
 
     volume = func.sum(DBWorkout.weight_kg * DBWorkout.repetitions)
     (
@@ -100,15 +101,16 @@ def get_location_stats(
         distinct_exercises,
     ) = (
         session.query(
-            func.count(distinct(DBWorkout.workout_time)),
+            func.count(distinct(DBWorkout.session_id)),
             func.count(DBWorkout.id),
             func.sum(DBWorkout.repetitions),
             volume,
             func.max(DBWorkout.weight_kg),
-            func.min(DBWorkout.workout_time),
-            func.max(DBWorkout.workout_time),
+            func.min(DBSession.workout_time),
+            func.max(DBSession.workout_time),
             func.count(distinct(DBWorkout.exercise_id)),
         )
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .filter(*conditions)
         .one()
     )
@@ -117,8 +119,9 @@ def get_location_stats(
     # distinct exercise count spans every visit, so it cannot be divided down.
     exercises_per_visit = (
         session.query(func.count(distinct(DBWorkout.exercise_id)).label("exercises"))
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .filter(*conditions)
-        .group_by(DBWorkout.workout_time)
+        .group_by(DBWorkout.session_id)
         .subquery()
     )
     average_exercises_per_visit = session.query(
@@ -129,11 +132,12 @@ def get_location_stats(
         session.query(
             DBWorkout.exercise_id,
             DBExercise.name,
-            func.count(distinct(DBWorkout.workout_time)).label("visits"),
+            func.count(distinct(DBWorkout.session_id)).label("visits"),
             func.count(DBWorkout.id).label("sets"),
             func.sum(DBWorkout.repetitions).label("repetitions"),
             volume.label("volume_kg"),
         )
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .join(DBExercise, DBExercise.id == DBWorkout.exercise_id)
         .filter(*conditions)
         .group_by(DBWorkout.exercise_id, DBExercise.name)

--- a/src/resolvers/go_heavier/migrations.py
+++ b/src/resolvers/go_heavier/migrations.py
@@ -7,6 +7,7 @@ from src.config import Config
 from src.migration_utils.google_sheets import (
     load_exercises_from_sheet,
     load_locations_from_sheet,
+    load_sessions_from_sheet,
     load_workouts_from_sheet,
 )
 from src.models import Base
@@ -21,10 +22,11 @@ logger = logging.getLogger(__name__)
 
 cfg = Config()
 
-# Locations and exercises are migrated first because workouts reference them.
+# Each table is migrated after the ones it references.
 MIGRATION_ORDER: Sequence[MigrationTable] = (
     MigrationTable.LOCATIONS,
     MigrationTable.EXERCISES,
+    MigrationTable.SESSIONS,
     MigrationTable.WORKOUTS,
 )
 
@@ -46,7 +48,15 @@ def _load_rows(table: MigrationTable, request: RunMigrationRequest) -> List[Base
         return load_locations_from_sheet(cfg=cfg)
     if table == MigrationTable.EXERCISES:
         return load_exercises_from_sheet(cfg=cfg)
-    return load_workouts_from_sheet(
+
+    # Sessions and sets come from the same sheet and take the same narrowing,
+    # so that a set is never loaded without the session it belongs to.
+    load = (
+        load_sessions_from_sheet
+        if table == MigrationTable.SESSIONS
+        else load_workouts_from_sheet
+    )
+    return load(
         cfg=cfg,
         range_start=request.workouts_row_start or 0,
         range_end=request.workouts_row_end,

--- a/src/resolvers/go_heavier/sessions.py
+++ b/src/resolvers/go_heavier/sessions.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import uuid
 from typing import List, Optional
 
@@ -24,6 +25,8 @@ from src.schemas.go_heavier.sessions import (
     SessionResponse,
     SessionSummary,
 )
+
+logger = logging.getLogger(__name__)
 
 # A session owns its sets, so the totals are an aggregate over the join.
 _SUMMARY_COLUMNS = (
@@ -334,3 +337,30 @@ def create_session(request: CreateSessionRequest) -> SessionResponse:
     session.commit()
 
     return get_session(session_id=session_id)
+
+
+def delete_session(session_id: uuid.UUID) -> bool:
+    """Delete a session and every set logged against it.
+
+    The sets belong to the session and are meaningless without it, since the
+    location and the time they were performed at live on the session.
+    """
+    db_session = session.query(DBSession).filter(DBSession.id == session_id).first()
+    if not db_session:
+        return False
+
+    try:
+        sets = (
+            session.query(DBWorkout)
+            .filter(DBWorkout.session_id == session_id)
+            .delete(synchronize_session=False)
+        )
+        session.delete(db_session)
+        session.commit()
+    except Exception:
+        # The session is shared across requests, so it must not be left dirty
+        session.rollback()
+        raise
+
+    logger.info(f"Deleted session {session_id} and the {sets} sets logged against it")
+    return True

--- a/src/resolvers/go_heavier/sessions.py
+++ b/src/resolvers/go_heavier/sessions.py
@@ -9,6 +9,12 @@ from src.models.go_heavier import Exercise as DBExercise
 from src.models.go_heavier import Location as DBLocation
 from src.models.go_heavier import Session as DBSession
 from src.models.go_heavier import Workout as DBWorkout
+from src.schemas.go_heavier.session_stats import (
+    SessionHighlight,
+    SessionStatsRequest,
+    SessionStatsResponse,
+    WeekdayStats,
+)
 from src.schemas.go_heavier.sessions import (
     ListSessionsRequest,
     SessionExerciseStats,
@@ -128,3 +134,148 @@ def get_session(session_id: uuid.UUID) -> Optional[SessionResponse]:
             for row in by_exercise
         ],
     )
+
+
+# Postgres numbers the week from Sunday, and a training log reads Monday first.
+_WEEKDAY_NAMES = {
+    1: "Monday",
+    2: "Tuesday",
+    3: "Wednesday",
+    4: "Thursday",
+    5: "Friday",
+    6: "Saturday",
+    0: "Sunday",
+}
+_WEEKDAY_ORDER = [1, 2, 3, 4, 5, 6, 0]
+
+
+def _stats_conditions(request: SessionStatsRequest) -> list:
+    conditions = []
+    if request.location_id:
+        conditions.append(DBSession.location_id == request.location_id)
+    if request.exercise_id:
+        conditions.append(
+            DBSession.id.in_(
+                select(DBWorkout.session_id).filter(
+                    DBWorkout.exercise_id == request.exercise_id
+                )
+            )
+        )
+    if request.after:
+        conditions.append(DBSession.workout_time >= request.after)
+    if request.before:
+        conditions.append(DBSession.workout_time <= request.before)
+
+    return conditions
+
+
+def _highlight(row) -> SessionHighlight:
+    return SessionHighlight(
+        id=row.id,
+        workout_time=row.workout_time,
+        location=row.location,
+        sets=row.sets,
+        volume_kg=round(row.volume_kg or 0.0, 2),
+    )
+
+
+def get_session_stats(request: SessionStatsRequest) -> SessionStatsResponse:
+    """Aggregate across sessions, rather than within one."""
+    conditions = _stats_conditions(request)
+
+    # The averages are per session, so they aggregate over the per session
+    # totals rather than over the sets directly.
+    per_session = _summary_query().filter(*conditions).subquery()
+    (
+        sessions,
+        first_session,
+        last_session,
+        average_sets,
+        average_exercises,
+        average_repetitions,
+        average_volume,
+    ) = session.query(
+        func.count(per_session.c.id),
+        func.min(per_session.c.workout_time),
+        func.max(per_session.c.workout_time),
+        func.avg(per_session.c.sets),
+        func.avg(per_session.c.exercises),
+        func.avg(per_session.c.repetitions),
+        func.avg(per_session.c.volume_kg),
+    ).one()
+
+    weekday = func.extract(
+        "dow", func.timezone("Europe/London", per_session.c.workout_time)
+    ).label("weekday")
+    by_weekday = {
+        int(row.weekday): row
+        for row in session.query(
+            weekday,
+            func.count(per_session.c.id).label("sessions"),
+            func.sum(per_session.c.sets).label("sets"),
+            func.sum(per_session.c.volume_kg).label("volume_kg"),
+        )
+        .group_by(weekday)
+        .all()
+    }
+
+    return SessionStatsResponse(
+        sessions=sessions,
+        first_session=first_session,
+        last_session=last_session,
+        average_sets_per_session=round(float(average_sets or 0.0), 2),
+        average_exercises_per_session=round(float(average_exercises or 0.0), 2),
+        average_repetitions_per_session=round(float(average_repetitions or 0.0), 2),
+        average_volume_kg_per_session=round(float(average_volume or 0.0), 2),
+        **_gaps_between(conditions),
+        busiest_session=_top_session(conditions, func.count(DBWorkout.id)),
+        heaviest_session=_top_session(
+            conditions, func.sum(DBWorkout.weight_kg * DBWorkout.repetitions)
+        ),
+        by_weekday=[
+            WeekdayStats(
+                weekday=_WEEKDAY_NAMES[day],
+                sessions=by_weekday[day].sessions,
+                sets=by_weekday[day].sets or 0,
+                volume_kg=round(by_weekday[day].volume_kg or 0.0, 2),
+            )
+            for day in _WEEKDAY_ORDER
+            if day in by_weekday
+        ],
+    )
+
+
+def _top_session(conditions: list, ordering) -> Optional[SessionHighlight]:
+    row = (
+        _summary_query().filter(*conditions).order_by(ordering.desc()).limit(1).first()
+    )
+
+    return _highlight(row) if row else None
+
+
+def _gaps_between(conditions: list) -> dict:
+    """The mean and longest gap between consecutive sessions, in days.
+
+    Computed over the session times rather than in SQL: there is one row per
+    session, the same filters bound it, and the arithmetic reads more plainly
+    here than as a window function nested two subqueries deep.
+    """
+    times = [
+        row.workout_time
+        for row in session.query(DBSession.workout_time)
+        .filter(*conditions)
+        .order_by(DBSession.workout_time)
+        .all()
+    ]
+    if len(times) < 2:
+        return {"average_days_between_sessions": None, "longest_gap_days": None}
+
+    gaps = [
+        (later - earlier).total_seconds() / 86400.0
+        for earlier, later in zip(times, times[1:])
+    ]
+
+    return {
+        "average_days_between_sessions": round(sum(gaps) / len(gaps), 2),
+        "longest_gap_days": round(max(gaps), 2),
+    }

--- a/src/resolvers/go_heavier/sessions.py
+++ b/src/resolvers/go_heavier/sessions.py
@@ -1,4 +1,4 @@
-import datetime
+import uuid
 from typing import List, Optional
 
 from sqlalchemy import distinct, func, select
@@ -7,6 +7,7 @@ from src.config import Config
 from src.db import session
 from src.models.go_heavier import Exercise as DBExercise
 from src.models.go_heavier import Location as DBLocation
+from src.models.go_heavier import Session as DBSession
 from src.models.go_heavier import Workout as DBWorkout
 from src.schemas.go_heavier.sessions import (
     ListSessionsRequest,
@@ -15,11 +16,11 @@ from src.schemas.go_heavier.sessions import (
     SessionSummary,
 )
 
-# A session is every set sharing one workout_time, so the summary of one is a
-# group by over that column. Each session has a single location.
+# A session owns its sets, so the totals are an aggregate over the join.
 _SUMMARY_COLUMNS = (
-    DBWorkout.workout_time,
-    DBWorkout.location_id,
+    DBSession.id,
+    DBSession.workout_time,
+    DBSession.location_id,
     DBLocation.name.label("location"),
     func.count(DBWorkout.id).label("sets"),
     func.count(distinct(DBWorkout.exercise_id)).label("exercises"),
@@ -27,10 +28,26 @@ _SUMMARY_COLUMNS = (
     func.sum(DBWorkout.weight_kg * DBWorkout.repetitions).label("volume_kg"),
     func.max(DBWorkout.weight_kg).label("heaviest_weight_kg"),
 )
+_GROUP_BY = (
+    DBSession.id,
+    DBSession.workout_time,
+    DBSession.location_id,
+    DBLocation.name,
+)
+
+
+def _summary_query():
+    return (
+        session.query(*_SUMMARY_COLUMNS)
+        .join(DBLocation, DBLocation.id == DBSession.location_id)
+        .join(DBWorkout, DBWorkout.session_id == DBSession.id)
+        .group_by(*_GROUP_BY)
+    )
 
 
 def _to_summary(row) -> SessionSummary:
     return SessionSummary(
+        id=row.id,
         workout_time=row.workout_time,
         location_id=row.location_id,
         location=row.location,
@@ -46,28 +63,26 @@ def get_sessions(request: ListSessionsRequest) -> List[SessionSummary]:
     """List sessions, most recent first."""
     conditions = []
     if request.location_id:
-        conditions.append(DBWorkout.location_id == request.location_id)
+        conditions.append(DBSession.location_id == request.location_id)
     if request.exercise_id:
         # Select the sessions that included the exercise, but still total up
         # every set in them rather than only that exercise's sets.
         conditions.append(
-            DBWorkout.workout_time.in_(
-                select(DBWorkout.workout_time).filter(
+            DBSession.id.in_(
+                select(DBWorkout.session_id).filter(
                     DBWorkout.exercise_id == request.exercise_id
                 )
             )
         )
     if request.after:
-        conditions.append(DBWorkout.workout_time >= request.after)
+        conditions.append(DBSession.workout_time >= request.after)
     if request.before:
-        conditions.append(DBWorkout.workout_time <= request.before)
+        conditions.append(DBSession.workout_time <= request.before)
 
     rows = (
-        session.query(*_SUMMARY_COLUMNS)
-        .join(DBLocation, DBLocation.id == DBWorkout.location_id)
+        _summary_query()
         .filter(*conditions)
-        .group_by(DBWorkout.workout_time, DBWorkout.location_id, DBLocation.name)
-        .order_by(DBWorkout.workout_time.desc())
+        .order_by(DBSession.workout_time.desc())
         .limit(Config.DEFAULT_DB_PAGE_SIZE)
         .offset(request.offset)
         .all()
@@ -76,15 +91,9 @@ def get_sessions(request: ListSessionsRequest) -> List[SessionSummary]:
     return [_to_summary(row) for row in rows]
 
 
-def get_session(workout_time: datetime.datetime) -> Optional[SessionResponse]:
+def get_session(session_id: uuid.UUID) -> Optional[SessionResponse]:
     """Return one session with its per exercise breakdown."""
-    summary = (
-        session.query(*_SUMMARY_COLUMNS)
-        .join(DBLocation, DBLocation.id == DBWorkout.location_id)
-        .filter(DBWorkout.workout_time == workout_time)
-        .group_by(DBWorkout.workout_time, DBWorkout.location_id, DBLocation.name)
-        .first()
-    )
+    summary = _summary_query().filter(DBSession.id == session_id).first()
     if not summary:
         return None
 
@@ -99,7 +108,7 @@ def get_session(workout_time: datetime.datetime) -> Optional[SessionResponse]:
             func.min(DBWorkout.index).label("first_set"),
         )
         .join(DBExercise, DBExercise.id == DBWorkout.exercise_id)
-        .filter(DBWorkout.workout_time == workout_time)
+        .filter(DBWorkout.session_id == session_id)
         .group_by(DBWorkout.exercise_id, DBExercise.name)
         .order_by("first_set", DBExercise.name)
         .all()

--- a/src/resolvers/go_heavier/sessions.py
+++ b/src/resolvers/go_heavier/sessions.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 from typing import List, Optional
 
@@ -5,6 +6,7 @@ from sqlalchemy import distinct, func, select
 
 from src.config import Config
 from src.db import session
+from src.migration_utils.session_ids import session_id_for
 from src.models.go_heavier import Exercise as DBExercise
 from src.models.go_heavier import Location as DBLocation
 from src.models.go_heavier import Session as DBSession
@@ -16,6 +18,7 @@ from src.schemas.go_heavier.session_stats import (
     WeekdayStats,
 )
 from src.schemas.go_heavier.sessions import (
+    CreateSessionRequest,
     ListSessionsRequest,
     SessionExerciseStats,
     SessionResponse,
@@ -46,7 +49,9 @@ def _summary_query():
     return (
         session.query(*_SUMMARY_COLUMNS)
         .join(DBLocation, DBLocation.id == DBSession.location_id)
-        .join(DBWorkout, DBWorkout.session_id == DBSession.id)
+        # Outer, so that a session created before anything is logged against
+        # it still reads back, with totals of zero rather than not at all.
+        .outerjoin(DBWorkout, DBWorkout.session_id == DBSession.id)
         .group_by(*_GROUP_BY)
     )
 
@@ -279,3 +284,53 @@ def _gaps_between(conditions: list) -> dict:
         "average_days_between_sessions": round(sum(gaps) / len(gaps), 2),
         "longest_gap_days": round(max(gaps), 2),
     }
+
+
+class LocationNotFound(LookupError):
+    """Raised when a session is created against a location that does not exist."""
+
+
+class SessionAlreadyExists(ValueError):
+    """Raised when a session has already been logged for that place and time.
+
+    Carries the existing id, since the caller almost certainly wants to log
+    against it rather than create another one.
+    """
+
+    def __init__(self, session_id: uuid.UUID) -> None:
+        self.session_id = session_id
+        super().__init__(f"A session already exists with id {session_id}")
+
+
+def create_session(request: CreateSessionRequest) -> SessionResponse:
+    """Create a session to log sets against.
+
+    The id is derived exactly as the sheet load derives it, so that a session
+    created here and the same visit arriving from the sheet are one row rather
+    than two competing for the unique constraint on the location and the time.
+    """
+    location = (
+        session.query(DBLocation).filter(DBLocation.id == request.location_id).first()
+    )
+    if not location:
+        raise LocationNotFound(f"No location with id {request.location_id}")
+
+    session_id = session_id_for(
+        location_id=request.location_id, workout_time=request.workout_time
+    )
+    if session.query(DBSession).filter(DBSession.id == session_id).first():
+        raise SessionAlreadyExists(session_id)
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    session.add(
+        DBSession(
+            id=session_id,
+            location_id=request.location_id,
+            workout_time=request.workout_time,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    session.commit()
+
+    return get_session(session_id=session_id)

--- a/src/resolvers/go_heavier/workouts.py
+++ b/src/resolvers/go_heavier/workouts.py
@@ -7,6 +7,7 @@ from src.config import Config
 from src.db import session
 from src.models.go_heavier import Exercise as DBExercise
 from src.models.go_heavier import Location as DBLocation
+from src.models.go_heavier import Session as DBSession
 from src.models.go_heavier import Workout as DBWorkout
 from src.schemas.go_heavier.workout_stats import (
     ExerciseBreakdown,
@@ -27,19 +28,22 @@ def get_workout(workout_id: uuid.UUID) -> Optional[DBWorkout]:
 
 def get_workouts(request: ListWorkoutsRequest) -> List[DBWorkout]:
     conditions = []
-    if request.location_id:
-        conditions.append(DBWorkout.location_id == request.location_id)
+    if request.session_id:
+        conditions.append(DBWorkout.session_id == request.session_id)
     if request.exercise_id:
         conditions.append(DBWorkout.exercise_id == request.exercise_id)
+    if request.location_id:
+        conditions.append(DBSession.location_id == request.location_id)
     if request.after:
-        conditions.append(DBWorkout.workout_time >= request.after)
+        conditions.append(DBSession.workout_time >= request.after)
     if request.before:
-        conditions.append(DBWorkout.workout_time <= request.before)
+        conditions.append(DBSession.workout_time <= request.before)
 
     query = (
         session.query(DBWorkout)
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .where(*conditions)
-        .order_by(DBWorkout.workout_time, DBWorkout.exercise_id, DBWorkout.index)
+        .order_by(DBSession.workout_time, DBWorkout.exercise_id, DBWorkout.index)
         .limit(Config.DEFAULT_DB_PAGE_SIZE)
     )
 
@@ -54,9 +58,8 @@ def create_workouts(workouts: CreateWorkoutsRequest) -> List[DBWorkout]:
     for workout in workouts.workouts:
         new_workouts.append(
             DBWorkout(
-                location_id=workout.location_id,  # relationship handled by db
+                session_id=workout.session_id,  # relationship handled by db
                 exercise_id=workout.exercise_id,  # relationship handled by db
-                workout_time=workout.workout_time,
                 index=workout.index,
                 repetitions=workout.repetitions,
                 weight_kg=workout.weight_kg,
@@ -104,13 +107,13 @@ def get_workout_stats(request: WorkoutStatsRequest) -> WorkoutStatsResponse:
     """
     conditions = []
     if request.location_id:
-        conditions.append(DBWorkout.location_id == request.location_id)
+        conditions.append(DBSession.location_id == request.location_id)
     if request.exercise_id:
         conditions.append(DBWorkout.exercise_id == request.exercise_id)
     if request.after:
-        conditions.append(DBWorkout.workout_time >= request.after)
+        conditions.append(DBSession.workout_time >= request.after)
     if request.before:
-        conditions.append(DBWorkout.workout_time <= request.before)
+        conditions.append(DBSession.workout_time <= request.before)
 
     volume = func.sum(DBWorkout.weight_kg * DBWorkout.repetitions)
     (
@@ -125,16 +128,17 @@ def get_workout_stats(request: WorkoutStatsRequest) -> WorkoutStatsResponse:
         distinct_exercises,
     ) = (
         session.query(
-            func.count(distinct(DBWorkout.workout_time)),
+            func.count(distinct(DBWorkout.session_id)),
             func.count(DBWorkout.id),
             func.sum(DBWorkout.repetitions),
             volume,
             func.max(DBWorkout.weight_kg),
-            func.min(DBWorkout.workout_time),
-            func.max(DBWorkout.workout_time),
-            func.count(distinct(DBWorkout.location_id)),
+            func.min(DBSession.workout_time),
+            func.max(DBSession.workout_time),
+            func.count(distinct(DBSession.location_id)),
             func.count(distinct(DBWorkout.exercise_id)),
         )
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .filter(*conditions)
         .one()
     )
@@ -143,8 +147,9 @@ def get_workout_stats(request: WorkoutStatsRequest) -> WorkoutStatsResponse:
     # exercise count spans every session, so it cannot be divided down.
     exercises_per_session = (
         session.query(func.count(distinct(DBWorkout.exercise_id)).label("exercises"))
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .filter(*conditions)
-        .group_by(DBWorkout.workout_time)
+        .group_by(DBWorkout.session_id)
         .subquery()
     )
     average_exercises_per_session = session.query(
@@ -153,16 +158,17 @@ def get_workout_stats(request: WorkoutStatsRequest) -> WorkoutStatsResponse:
 
     top_locations = (
         session.query(
-            DBWorkout.location_id,
+            DBSession.location_id,
             DBLocation.name,
-            func.count(distinct(DBWorkout.workout_time)).label("sessions"),
+            func.count(distinct(DBWorkout.session_id)).label("sessions"),
             func.count(DBWorkout.id).label("sets"),
             func.sum(DBWorkout.repetitions).label("repetitions"),
             volume.label("volume_kg"),
         )
-        .join(DBLocation, DBLocation.id == DBWorkout.location_id)
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
+        .join(DBLocation, DBLocation.id == DBSession.location_id)
         .filter(*conditions)
-        .group_by(DBWorkout.location_id, DBLocation.name)
+        .group_by(DBSession.location_id, DBLocation.name)
         .order_by(desc("sets"), DBLocation.name)
         .limit(request.top_locations)
         .all()
@@ -172,11 +178,12 @@ def get_workout_stats(request: WorkoutStatsRequest) -> WorkoutStatsResponse:
         session.query(
             DBWorkout.exercise_id,
             DBExercise.name,
-            func.count(distinct(DBWorkout.workout_time)).label("sessions"),
+            func.count(distinct(DBWorkout.session_id)).label("sessions"),
             func.count(DBWorkout.id).label("sets"),
             func.sum(DBWorkout.repetitions).label("repetitions"),
             volume.label("volume_kg"),
         )
+        .join(DBSession, DBSession.id == DBWorkout.session_id)
         .join(DBExercise, DBExercise.id == DBWorkout.exercise_id)
         .filter(*conditions)
         .group_by(DBWorkout.exercise_id, DBExercise.name)

--- a/src/routers/go_heavier/sessions.py
+++ b/src/routers/go_heavier/sessions.py
@@ -1,4 +1,4 @@
-import datetime
+import uuid
 from typing import Annotated, List
 
 from fastapi import APIRouter, HTTPException, Query
@@ -20,21 +20,16 @@ async def get_sessions(
     return sessions.get_sessions(request=request)
 
 
-@router.get("/sessions/{workout_time}", response_model=SessionResponse)
-async def get_session(workout_time: str) -> SessionResponse:
+@router.get("/sessions/{session_id}", response_model=SessionResponse)
+async def get_session(session_id: Annotated[str, uuid.UUID]) -> SessionResponse:
     try:
-        parsed = datetime.datetime.fromisoformat(workout_time)
+        session_uuid = uuid.UUID(session_id)
     except ValueError:
         raise HTTPException(
             status_code=400,
-            detail={"detail": "Invalid format for workout time, expected ISO 8601"},
+            detail={"detail": "Invalid format for session id"},
         )
-    # A session key read off a listing is in UTC, and a bare one is taken as UTC
-    # rather than as the server's local time.
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
-
-    workout_session = sessions.get_session(workout_time=parsed)
+    workout_session = sessions.get_session(session_id=session_uuid)
     if not workout_session:
         raise HTTPException(status_code=404, detail="Session not found")
     return workout_session

--- a/src/routers/go_heavier/sessions.py
+++ b/src/routers/go_heavier/sessions.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from typing import Annotated, List
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Response
 
 from src.resolvers.go_heavier import sessions
 from src.resolvers.go_heavier.sessions import (
@@ -69,3 +69,18 @@ async def get_session(session_id: Annotated[str, uuid.UUID]) -> SessionResponse:
     if not workout_session:
         raise HTTPException(status_code=404, detail="Session not found")
     return workout_session
+
+
+@router.delete("/sessions/{session_id}", status_code=204)
+async def delete_session(session_id: Annotated[str, uuid.UUID]) -> Response:
+    """Delete a session and every set logged against it."""
+    try:
+        session_uuid = uuid.UUID(session_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail={"detail": "Invalid format for session id"},
+        )
+    if not sessions.delete_session(session_id=session_uuid):
+        raise HTTPException(status_code=404, detail="Session not found")
+    return Response(status_code=204)

--- a/src/routers/go_heavier/sessions.py
+++ b/src/routers/go_heavier/sessions.py
@@ -1,18 +1,26 @@
+import logging
 import uuid
 from typing import Annotated, List
 
 from fastapi import APIRouter, HTTPException, Query
 
 from src.resolvers.go_heavier import sessions
+from src.resolvers.go_heavier.sessions import (
+    LocationNotFound,
+    SessionAlreadyExists,
+)
 from src.schemas.go_heavier.session_stats import (
     SessionStatsRequest,
     SessionStatsResponse,
 )
 from src.schemas.go_heavier.sessions import (
+    CreateSessionRequest,
     ListSessionsRequest,
     SessionResponse,
     SessionSummary,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/go-heavier", tags=["sessions"])
 
@@ -22,6 +30,22 @@ async def get_sessions(
     request: Annotated[ListSessionsRequest, Query()],
 ) -> List[SessionSummary]:
     return sessions.get_sessions(request=request)
+
+
+@router.post("/sessions", response_model=SessionResponse, status_code=201)
+async def create_session(request: CreateSessionRequest) -> SessionResponse:
+    try:
+        return sessions.create_session(request=request)
+    except LocationNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except SessionAlreadyExists as e:
+        raise HTTPException(
+            status_code=409,
+            detail={"detail": str(e), "session_id": str(e.session_id)},
+        )
+    except Exception as e:
+        logger.error(f"Error creating session: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/sessions/stats", response_model=SessionStatsResponse)

--- a/src/routers/go_heavier/sessions.py
+++ b/src/routers/go_heavier/sessions.py
@@ -4,6 +4,10 @@ from typing import Annotated, List
 from fastapi import APIRouter, HTTPException, Query
 
 from src.resolvers.go_heavier import sessions
+from src.schemas.go_heavier.session_stats import (
+    SessionStatsRequest,
+    SessionStatsResponse,
+)
 from src.schemas.go_heavier.sessions import (
     ListSessionsRequest,
     SessionResponse,
@@ -20,6 +24,14 @@ async def get_sessions(
     return sessions.get_sessions(request=request)
 
 
+@router.get("/sessions/stats", response_model=SessionStatsResponse)
+async def get_session_stats(
+    request: Annotated[SessionStatsRequest, Query()],
+) -> SessionStatsResponse:
+    return sessions.get_session_stats(request=request)
+
+
+# Declared after /sessions/stats so that "stats" is not read as a session id
 @router.get("/sessions/{session_id}", response_model=SessionResponse)
 async def get_session(session_id: Annotated[str, uuid.UUID]) -> SessionResponse:
     try:

--- a/src/routers/go_heavier/workouts.py
+++ b/src/routers/go_heavier/workouts.py
@@ -52,7 +52,8 @@ async def get_workouts(
     return workouts.get_workouts(request=request)
 
 
-@router.post("/workouts", response_model=WorkoutResponse)
+# The request takes a list of sets, so the response is the list that was created
+@router.post("/workouts", response_model=List[WorkoutResponse], status_code=201)
 async def create_workout(
     workouts_: CreateWorkoutsRequest,
 ) -> Optional[List[DBWorkout]]:

--- a/src/schemas/go_heavier/migrations.py
+++ b/src/schemas/go_heavier/migrations.py
@@ -13,6 +13,7 @@ from pydantic import (
 class MigrationTable(str, enum.Enum):
     LOCATIONS = "locations"
     EXERCISES = "exercises"
+    SESSIONS = "sessions"
     WORKOUTS = "workouts"
 
 

--- a/src/schemas/go_heavier/session_stats.py
+++ b/src/schemas/go_heavier/session_stats.py
@@ -1,0 +1,121 @@
+"""Schemas for the aggregated view across sessions."""
+
+import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+)
+
+
+class SessionStatsRequest(BaseModel):
+    """Query parameters for narrowing the session stats."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    location_id: Optional[UUID] = Field(
+        description="Only count sessions at this location",
+        default=None,
+    )
+    exercise_id: Optional[UUID] = Field(
+        description="Only count sessions that included this exercise. The totals "
+        "still cover every set in them, not just that exercise",
+        default=None,
+    )
+    after: Optional[AwareDatetime] = Field(
+        description="Only count sessions at or after this datetime",
+        default=None,
+    )
+    before: Optional[AwareDatetime] = Field(
+        description="Only count sessions at or before this datetime",
+        default=None,
+    )
+
+
+class SessionHighlight(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(description="Unique identifier for the session")
+    workout_time: AwareDatetime = Field(description="When the session took place")
+    location: str = Field(description="Name of the location")
+    sets: int = Field(description="Number of sets logged in the session")
+    volume_kg: float = Field(
+        description="Total weight moved, the sum of weight_kg multiplied by repetitions"
+    )
+
+    @field_validator("workout_time", mode="before")
+    @classmethod
+    def ensure_timezone_aware(cls, value):
+        """Convert naive datetimes to timezone-aware datetimes (UTC)"""
+        if isinstance(value, datetime.datetime) and value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value
+
+
+class WeekdayStats(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    weekday: str = Field(description="Day of the week, in UK local time")
+    sessions: int = Field(description="Number of sessions on this day")
+    sets: int = Field(description="Number of sets logged on this day")
+    volume_kg: float = Field(
+        description="Total weight moved, the sum of weight_kg multiplied by repetitions"
+    )
+
+
+class SessionStatsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    sessions: int = Field(description="Number of sessions counted")
+    first_session: Optional[AwareDatetime] = Field(
+        description="When the earliest session took place", default=None
+    )
+    last_session: Optional[AwareDatetime] = Field(
+        description="When the most recent session took place", default=None
+    )
+    average_sets_per_session: float = Field(
+        description="Mean number of sets in a session, 0 when there are none"
+    )
+    average_exercises_per_session: float = Field(
+        description="Mean number of different exercises in a session"
+    )
+    average_repetitions_per_session: float = Field(
+        description="Mean number of repetitions in a session"
+    )
+    average_volume_kg_per_session: float = Field(
+        description="Mean weight moved in a session"
+    )
+    average_days_between_sessions: Optional[float] = Field(
+        description="Mean gap between consecutive sessions, null with fewer than two",
+        default=None,
+    )
+    longest_gap_days: Optional[float] = Field(
+        description="Longest gap between consecutive sessions, null with fewer than two",
+        default=None,
+    )
+    busiest_session: Optional[SessionHighlight] = Field(
+        description="The session with the most sets", default=None
+    )
+    heaviest_session: Optional[SessionHighlight] = Field(
+        description="The session that moved the most weight", default=None
+    )
+    by_weekday: List[WeekdayStats] = Field(
+        description="Breakdown by day of the week, Monday first, omitting days "
+        "with no sessions",
+        default_factory=list,
+    )
+
+    @field_validator("first_session", "last_session", mode="before")
+    @classmethod
+    def ensure_timezone_aware(cls, value):
+        """Convert naive datetimes to timezone-aware datetimes (UTC)"""
+        if value is None:
+            return None
+        if isinstance(value, datetime.datetime) and value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value

--- a/src/schemas/go_heavier/sessions.py
+++ b/src/schemas/go_heavier/sessions.py
@@ -42,9 +42,8 @@ class ListSessionsRequest(PaginationParams):
 class _BaseSession(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    workout_time: AwareDatetime = Field(
-        description="When the session took place, the key identifying it"
-    )
+    id: UUID = Field(description="Unique identifier for the session")
+    workout_time: AwareDatetime = Field(description="When the session took place")
     location_id: UUID = Field(description="Unique identifier for the location")
     location: str = Field(description="Name of the location")
     sets: int = Field(description="Number of sets logged in the session")

--- a/src/schemas/go_heavier/sessions.py
+++ b/src/schemas/go_heavier/sessions.py
@@ -52,8 +52,10 @@ class _BaseSession(BaseModel):
     volume_kg: float = Field(
         description="Total weight moved, the sum of weight_kg multiplied by repetitions"
     )
-    heaviest_weight_kg: float = Field(
-        description="The heaviest single weight lifted in the session"
+    heaviest_weight_kg: Optional[float] = Field(
+        description="The heaviest single weight lifted in the session, null "
+        "while nothing has been logged against it yet",
+        default=None,
     )
 
     @field_validator("workout_time", mode="before")
@@ -80,6 +82,15 @@ class SessionExerciseStats(BaseModel):
     heaviest_weight_kg: float = Field(
         description="The heaviest single weight lifted for this exercise"
     )
+
+
+class CreateSessionRequest(BaseModel):
+    """A visit to a gym, to log sets against."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    location_id: UUID = Field(description="Where the session took place")
+    workout_time: AwareDatetime = Field(description="When the session took place")
 
 
 class SessionSummary(_BaseSession):

--- a/src/schemas/go_heavier/workouts.py
+++ b/src/schemas/go_heavier/workouts.py
@@ -1,6 +1,6 @@
 import math
 from datetime import datetime, timezone
-from typing import Annotated, List, Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
@@ -11,18 +11,14 @@ from src.schemas.utils import PaginationParams
 class _BaseWorkout(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    location_id: UUID = Field(
-        description="Unique identifier for this workout location",
+    session_id: UUID = Field(
+        description="Unique identifier for the session this set belongs to. The "
+        "location and the time are on the session",
         nullable=False,
     )
     exercise_id: UUID = Field(
         description="Unique identifier for this workout exercise",
         nullable=False,
-    )
-    workout_time: AwareDatetime = Field(
-        description="The date and time when the workout was performed",
-        nullable=False,
-        default=None,
     )
     index: int = Field(
         description="The index of the set within the workout session",
@@ -94,50 +90,27 @@ class UpdateWorkoutRequest(_BaseWorkout):
 
 class ListWorkoutsRequest(PaginationParams):
     model_config = ConfigDict(from_attributes=True)
-    exercise_id: Optional[
-        Annotated[
-            UUID,
-            Field(
-                description="Unique identifier for filtering workouts by exercise",
-                min_length=32,
-                max_length=36,
-                nullable=True,
-                default=None,
-            ),
-        ]
-    ] = None
-    location_id: Optional[
-        Annotated[
-            UUID,
-            Field(
-                description="Unique identifier for filtering workouts by location",
-                min_length=32,
-                max_length=36,
-                nullable=True,
-                default=None,
-            ),
-        ]
-    ] = None
-    after: Optional[
-        Annotated[
-            AwareDatetime,
-            Field(
-                description="Filter workouts created after this datetime",
-                nullable=True,
-                default=None,
-            ),
-        ]
-    ] = None
-    before: Optional[
-        Annotated[
-            AwareDatetime,
-            Field(
-                description="Filter workouts created before this datetime",
-                nullable=True,
-                default=None,
-            ),
-        ]
-    ] = None
+
+    exercise_id: Optional[UUID] = Field(
+        description="Only list sets of this exercise",
+        default=None,
+    )
+    location_id: Optional[UUID] = Field(
+        description="Only list sets from sessions at this location",
+        default=None,
+    )
+    after: Optional[AwareDatetime] = Field(
+        description="Only list sets from sessions at or after this datetime",
+        default=None,
+    )
+    before: Optional[AwareDatetime] = Field(
+        description="Only list sets from sessions at or before this datetime",
+        default=None,
+    )
+    session_id: Optional[UUID] = Field(
+        description="Only list sets from this session",
+        default=None,
+    )
 
 
 class WorkoutResponse(_BaseWorkout):
@@ -145,7 +118,7 @@ class WorkoutResponse(_BaseWorkout):
     created_at: AwareDatetime
     updated_at: Optional[AwareDatetime]
 
-    @field_validator("created_at", "updated_at", "workout_time", mode="before")
+    @field_validator("created_at", "updated_at", mode="before")
     @classmethod
     def ensure_timezone_aware(cls, value):
         """Convert naive datetimes to timezone-aware datetimes (UTC)"""

--- a/tests/test_session_ids.py
+++ b/tests/test_session_ids.py
@@ -1,0 +1,83 @@
+import datetime
+import uuid
+
+import pytest
+
+from src.migration_utils.session_ids import (
+    SESSION_NAMESPACE,
+    session_id_for,
+    session_key,
+)
+
+LOCATION = uuid.UUID("62655708-0330-475f-aa28-c4749ded4b9d")
+WORKOUT_TIME = datetime.datetime(2026, 8, 20, 21, 20, tzinfo=datetime.timezone.utc)
+
+
+class TestSessionKey:
+    """Test the string a session's id is derived from."""
+
+    def test_the_key_pairs_the_location_with_the_time(self):
+        assert session_key(LOCATION, WORKOUT_TIME) == f"{LOCATION}|2026-08-20T21:20:00Z"
+
+    def test_an_offset_time_is_normalised_to_utc(self):
+        """The same instant must give the same key however it is expressed."""
+        bst = datetime.datetime(
+            2026,
+            8,
+            20,
+            22,
+            20,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=1)),
+        )
+
+        assert session_key(LOCATION, bst) == session_key(LOCATION, WORKOUT_TIME)
+
+    def test_a_naive_time_is_read_as_utc(self):
+        naive = datetime.datetime(2026, 8, 20, 21, 20)
+
+        assert session_key(LOCATION, naive) == session_key(LOCATION, WORKOUT_TIME)
+
+    def test_microseconds_are_dropped(self):
+        """A stray microsecond must not split one session into two."""
+        precise = WORKOUT_TIME.replace(microsecond=123456)
+
+        assert session_key(LOCATION, precise) == session_key(LOCATION, WORKOUT_TIME)
+
+
+class TestSessionIdFor:
+    """Test the derived session id.
+
+    Re-running the sheet load must merge onto the same rows, so these ids are
+    a contract: changing how they are derived orphans every existing session.
+    """
+
+    def test_the_id_is_stable(self):
+        assert session_id_for(LOCATION, WORKOUT_TIME) == uuid.UUID(
+            "6cd3905a-3bfa-53ca-a9e4-331557a3c04c"
+        )
+
+    def test_the_same_session_gives_the_same_id(self):
+        assert session_id_for(LOCATION, WORKOUT_TIME) == session_id_for(
+            LOCATION, WORKOUT_TIME
+        )
+
+    def test_a_different_time_gives_a_different_id(self):
+        other = WORKOUT_TIME + datetime.timedelta(minutes=1)
+
+        assert session_id_for(LOCATION, other) != session_id_for(LOCATION, WORKOUT_TIME)
+
+    def test_a_different_location_gives_a_different_id(self):
+        other = uuid.UUID("97cffa7f-6b99-47a0-9a3f-adbbb7409dea")
+
+        assert session_id_for(other, WORKOUT_TIME) != session_id_for(
+            LOCATION, WORKOUT_TIME
+        )
+
+    def test_the_id_is_a_uuid5(self):
+        assert session_id_for(LOCATION, WORKOUT_TIME).version == 5
+
+    @pytest.mark.parametrize(
+        "namespace", [uuid.NAMESPACE_DNS, uuid.NAMESPACE_URL, uuid.uuid4()]
+    )
+    def test_the_namespace_is_not_a_standard_one(self, namespace: uuid.UUID):
+        assert SESSION_NAMESPACE != namespace

--- a/tests/test_session_schema.py
+++ b/tests/test_session_schema.py
@@ -14,6 +14,7 @@ from src.schemas.go_heavier.sessions import (
 
 def _payload(**overrides) -> dict:
     payload = {
+        "id": uuid4(),
         "workout_time": datetime(2026, 8, 20, 21, 20, tzinfo=timezone.utc),
         "location_id": uuid4(),
         "location": "The Gym Greenford",
@@ -42,6 +43,12 @@ class TestSessionSummary:
         workout_time = datetime(2026, 8, 20, 21, 20, tzinfo=timezone.utc)
 
         assert SessionSummary(**_payload()).workout_time == workout_time
+
+    def test_the_session_is_identified_by_its_own_id(self):
+        """The id is stable, unlike the time it was previously keyed on."""
+        session_id = uuid4()
+
+        assert SessionSummary(**_payload(id=session_id)).id == session_id
 
     def test_an_assisted_session_can_be_heaviest_negative(self):
         """A session of only assisted work has a negative heaviest weight."""

--- a/tests/test_session_schema.py
+++ b/tests/test_session_schema.py
@@ -5,11 +5,14 @@ import pytest
 from pydantic import ValidationError
 
 from src.schemas.go_heavier.sessions import (
+    CreateSessionRequest,
     ListSessionsRequest,
     SessionExerciseStats,
     SessionResponse,
     SessionSummary,
 )
+
+LOCATION_ID = uuid4()
 
 
 def _payload(**overrides) -> dict:
@@ -120,3 +123,60 @@ class TestListSessionsRequest:
     def test_malformed_id_filters_are_rejected(self):
         with pytest.raises(ValidationError):
             ListSessionsRequest(exercise_id="not-a-uuid")
+
+
+class TestCreateSessionRequest:
+    """Test the body for creating a session to log sets against."""
+
+    def test_a_location_and_a_time_are_required(self):
+        request = CreateSessionRequest(
+            location_id=LOCATION_ID,
+            workout_time=datetime(2026, 9, 1, 18, 0, tzinfo=timezone.utc),
+        )
+
+        assert request.location_id == LOCATION_ID
+
+    @pytest.mark.parametrize("missing", ["location_id", "workout_time"])
+    def test_neither_may_be_omitted(self, missing: str):
+        payload = {
+            "location_id": LOCATION_ID,
+            "workout_time": datetime(2026, 9, 1, 18, 0, tzinfo=timezone.utc),
+        }
+        del payload[missing]
+
+        with pytest.raises(ValidationError):
+            CreateSessionRequest(**payload)
+
+    def test_a_naive_time_is_rejected(self):
+        """An offset is required, since the stored time is an instant in UTC."""
+        with pytest.raises(ValidationError):
+            CreateSessionRequest(
+                location_id=LOCATION_ID, workout_time=datetime(2026, 9, 1, 18, 0)
+            )
+
+    def test_a_malformed_location_is_rejected(self):
+        with pytest.raises(ValidationError):
+            CreateSessionRequest(
+                location_id="not-a-uuid",
+                workout_time=datetime(2026, 9, 1, 18, 0, tzinfo=timezone.utc),
+            )
+
+
+class TestEmptySession:
+    """Test a session created before anything has been logged against it."""
+
+    def test_it_has_no_heaviest_weight(self):
+        """Nothing has been lifted yet, which is not the same as lifting zero."""
+        summary = SessionSummary(
+            **{
+                **_payload(),
+                "sets": 0,
+                "exercises": 0,
+                "repetitions": 0,
+                "volume_kg": 0.0,
+                "heaviest_weight_kg": None,
+            }
+        )
+
+        assert summary.heaviest_weight_kg is None
+        assert summary.sets == 0

--- a/tests/test_session_schema.py
+++ b/tests/test_session_schema.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
+from src.migration_utils.session_ids import session_id_for
 from src.schemas.go_heavier.sessions import (
     CreateSessionRequest,
     ListSessionsRequest,
@@ -180,3 +181,20 @@ class TestEmptySession:
 
         assert summary.heaviest_weight_kg is None
         assert summary.sets == 0
+
+
+class TestSessionIdentityIsRecoverable:
+    """The derived id means a session can be rebuilt from what identifies it.
+
+    This matters for delete: recreating a session that was removed by mistake
+    restores the same id, so anything still referring to it lines up again.
+    """
+
+    def test_the_same_location_and_time_rebuild_the_same_id(self):
+        location_id = uuid4()
+        workout_time = datetime(2026, 8, 22, 17, 30, tzinfo=timezone.utc)
+
+        first = session_id_for(location_id=location_id, workout_time=workout_time)
+        rebuilt = session_id_for(location_id=location_id, workout_time=workout_time)
+
+        assert first == rebuilt

--- a/tests/test_session_stats_schema.py
+++ b/tests/test_session_stats_schema.py
@@ -1,0 +1,122 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.schemas.go_heavier.session_stats import (
+    SessionHighlight,
+    SessionStatsRequest,
+    SessionStatsResponse,
+    WeekdayStats,
+)
+
+
+def _stats(**overrides) -> SessionStatsResponse:
+    payload = {
+        "sessions": 63,
+        "average_sets_per_session": 20.02,
+        "average_exercises_per_session": 6.67,
+        "average_repetitions_per_session": 203.37,
+        "average_volume_kg_per_session": 9039.06,
+    }
+    payload.update(overrides)
+    return SessionStatsResponse(**payload)
+
+
+def _highlight(**overrides) -> dict:
+    payload = {
+        "id": uuid4(),
+        "workout_time": datetime(2026, 5, 29, 8, 0, tzinfo=timezone.utc),
+        "location": "The Gym Wealdstone",
+        "sets": 42,
+        "volume_kg": 12672.0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestSessionStatsResponse:
+    """Test the shape of the aggregate session stats."""
+
+    def test_naive_times_are_made_timezone_aware(self):
+        stats = _stats(
+            first_session=datetime(2025, 8, 10, 13, 0),
+            last_session=datetime(2026, 8, 20, 21, 20),
+        )
+
+        assert stats.first_session == datetime(2025, 8, 10, 13, 0, tzinfo=timezone.utc)
+        assert stats.last_session == datetime(2026, 8, 20, 21, 20, tzinfo=timezone.utc)
+
+    def test_gaps_are_absent_rather_than_zero_for_one_session(self):
+        """With nothing to measure between, a gap of zero would be a lie."""
+        stats = _stats(sessions=1)
+
+        assert stats.average_days_between_sessions is None
+        assert stats.longest_gap_days is None
+
+    def test_no_matching_sessions(self):
+        stats = _stats(
+            sessions=0,
+            average_sets_per_session=0.0,
+            average_exercises_per_session=0.0,
+            average_repetitions_per_session=0.0,
+            average_volume_kg_per_session=0.0,
+        )
+
+        assert stats.first_session is None
+        assert stats.busiest_session is None
+        assert stats.heaviest_session is None
+        assert stats.by_weekday == []
+
+    def test_the_highlights_are_parsed(self):
+        busiest = _highlight()
+        stats = _stats(busiest_session=busiest, heaviest_session=_highlight(sets=25))
+
+        assert stats.busiest_session == SessionHighlight(**busiest)
+        assert stats.heaviest_session.sets == 25
+
+    def test_a_highlight_time_is_made_timezone_aware(self):
+        stats = _stats(
+            busiest_session=_highlight(workout_time=datetime(2026, 5, 29, 8, 0))
+        )
+
+        assert stats.busiest_session.workout_time.tzinfo is not None
+
+    def test_the_weekday_breakdown_is_parsed(self):
+        stats = _stats(
+            by_weekday=[
+                {
+                    "weekday": "Friday",
+                    "sessions": 15,
+                    "sets": 322,
+                    "volume_kg": 143668.4,
+                }
+            ]
+        )
+
+        assert stats.by_weekday == [
+            WeekdayStats(weekday="Friday", sessions=15, sets=322, volume_kg=143668.4)
+        ]
+
+
+class TestSessionStatsRequest:
+    """Test the query parameters that narrow the session stats."""
+
+    def test_defaults(self):
+        request = SessionStatsRequest()
+
+        assert request.location_id is None
+        assert request.exercise_id is None
+        assert request.after is None
+        assert request.before is None
+
+    def test_naive_bounds_are_rejected(self):
+        """Bounds must be timezone aware so they can be compared to workout_time."""
+        with pytest.raises(ValidationError):
+            SessionStatsRequest(after=datetime(2026, 8, 1, 0, 0))
+
+    @pytest.mark.parametrize("field", ["location_id", "exercise_id"])
+    def test_malformed_id_filters_are_rejected(self, field: str):
+        with pytest.raises(ValidationError):
+            SessionStatsRequest(**{field: "not-a-uuid"})

--- a/tests/test_sheet_loaders.py
+++ b/tests/test_sheet_loaders.py
@@ -1,0 +1,430 @@
+"""Tests for building models out of the Google Sheet.
+
+The loaders are exercised against fake worksheets rather than the real
+spreadsheet, so they run without credentials or a database.
+"""
+
+import datetime
+import logging
+import uuid
+
+import pytest
+
+from src.migration_utils import google_sheets
+from src.migration_utils.session_ids import session_id_for
+
+GYM = uuid.UUID("62655708-0330-475f-aa28-c4749ded4b9d")
+OTHER_GYM = uuid.UUID("97cffa7f-6b99-47a0-9a3f-adbbb7409dea")
+BENCH = uuid.UUID("55c2fa3a-789b-4431-a207-018636eec66c")
+CRUNCH = uuid.UUID("214b75cd-e331-414e-9189-50bbe4ca5e15")
+
+WORKOUT_HEADER = [
+    "id",
+    "location",
+    "workout_time",
+    "exercise",
+    "index",
+    "weight_kg",
+    "repetitions",
+    "bar_weight_kg",
+    "supplementary_weight_kg",
+    "weight_lb",
+    "notes",
+]
+
+
+def workout_row(
+    location="",
+    workout_time="",
+    exercise="",
+    index="",
+    weight_kg="",
+    repetitions="",
+    bar="",
+    supplementary="",
+    weight_lb="",
+    notes="",
+    row_id=None,
+) -> list:
+    """A workouts sheet row. Blank columns are inherited from the row above."""
+    return [
+        str(row_id or uuid.uuid4()),
+        location,
+        workout_time,
+        exercise,
+        index,
+        weight_kg,
+        repetitions,
+        bar,
+        supplementary,
+        weight_lb,
+        notes,
+    ]
+
+
+class FakeWorksheet:
+    def __init__(self, rows: list):
+        self._rows = rows
+
+    def get_all_values(self) -> list:
+        return self._rows
+
+
+@pytest.fixture
+def workouts_sheet(monkeypatch):
+    """Install a fake workouts sheet, returning a setter for its rows."""
+    monkeypatch.setattr(
+        google_sheets,
+        "get_locations_mapping",
+        lambda cfg=None: {"Gym": GYM, "Other": OTHER_GYM},
+    )
+    monkeypatch.setattr(
+        google_sheets,
+        "get_exercises_mapping",
+        lambda cfg=None: {"Bench Press": BENCH, "Crunch": CRUNCH},
+    )
+
+    def set_rows(*rows):
+        sheet = FakeWorksheet([WORKOUT_HEADER, *rows])
+        monkeypatch.setattr(google_sheets, "get_workouts", lambda cfg=None: sheet)
+
+    return set_rows
+
+
+class TestLoadWorkouts:
+    """Test building the sets of a session out of the sheet."""
+
+    def test_a_single_set_is_loaded(self, workouts_sheet):
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+            )
+        )
+
+        (workout,) = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert workout.exercise_id == BENCH
+        assert workout.index == 1
+        assert workout.repetitions == 10
+        assert workout.weight_kg == 50.0
+
+    def test_blank_columns_are_inherited_from_the_row_above(self, workouts_sheet):
+        """Only the first row of a session repeats the location and the time."""
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+            ),
+            workout_row(weight_kg="55", repetitions="8"),
+            workout_row(weight_kg="60", repetitions="6"),
+        )
+
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert [w.exercise_id for w in workouts] == [BENCH, BENCH, BENCH]
+        assert len({w.session_id for w in workouts}) == 1
+
+    def test_sets_are_numbered_within_the_exercise(self, workouts_sheet):
+        """The index restarts when a new exercise names itself."""
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+            ),
+            workout_row(weight_kg="55", repetitions="8"),
+            workout_row(exercise="Crunch", index="1", weight_kg="20", repetitions="15"),
+            workout_row(weight_kg="25", repetitions="12"),
+        )
+
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert [w.index for w in workouts] == [1, 2, 1, 2]
+
+    def test_a_blank_row_does_not_shift_the_set_numbering(self, workouts_sheet):
+        """A spacer row must not be counted as a set of the exercise above it."""
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+            ),
+            [""] * len(WORKOUT_HEADER),
+            workout_row(weight_kg="55", repetitions="8"),
+        )
+
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert [w.index for w in workouts] == [1, 2]
+
+    @pytest.mark.parametrize("missing", ["weight_kg", "repetitions"])
+    def test_a_row_missing_a_required_value_is_skipped(
+        self, workouts_sheet, caplog, missing: str
+    ):
+        complete = {
+            "weight_kg": "50",
+            "repetitions": "10",
+        }
+        incomplete = {**complete, missing: ""}
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                **complete,
+            ),
+            workout_row(**incomplete),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            workouts = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert len(workouts) == 1
+        assert "sheet row 3" in caplog.text
+        assert missing in caplog.text
+
+    def test_a_column_the_model_does_not_have_is_ignored(self, workouts_sheet):
+        """The sheet records a weight in pounds that the database does not hold."""
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="12.47",
+                repetitions="10",
+                weight_lb="27.5",
+            )
+        )
+
+        (workout,) = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert workout.weight_kg == 12.47
+        assert not hasattr(workout, "weight_lb")
+
+    def test_a_blank_note_is_null_rather_than_the_string_none(self, workouts_sheet):
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+                notes="felt good",
+            ),
+            workout_row(weight_kg="55", repetitions="8"),
+        )
+
+        first, second = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert first.notes == "felt good"
+        assert second.notes is None
+
+    def test_an_assisted_set_keeps_its_negative_weight(self, workouts_sheet):
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="-59",
+                repetitions="10",
+            )
+        )
+
+        (workout,) = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert workout.weight_kg == -59.0
+
+    def test_a_typographic_dash_in_the_time_still_parses(self, workouts_sheet):
+        """A spreadsheet autocorrects a hyphen into an en dash."""
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026–08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+            )
+        )
+
+        (session,) = google_sheets.load_sessions_from_sheet(cfg=None)
+
+        assert session.workout_time.date() == datetime.date(2026, 8, 7)
+
+
+class TestWorkoutTimeZone:
+    """Test that times typed as UK local time are stored as UTC."""
+
+    def test_british_summer_time_shifts_by_an_hour(self, workouts_sheet):
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-08-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+            )
+        )
+
+        (session,) = google_sheets.load_sessions_from_sheet(cfg=None)
+
+        assert session.workout_time.hour == 13
+
+    def test_greenwich_mean_time_does_not_shift(self, workouts_sheet):
+        workouts_sheet(
+            workout_row(
+                location="Gym",
+                workout_time="2026-01-07T14:30:00",
+                exercise="Bench Press",
+                index="1",
+                weight_kg="50",
+                repetitions="10",
+            )
+        )
+
+        (session,) = google_sheets.load_sessions_from_sheet(cfg=None)
+
+        assert session.workout_time.hour == 14
+
+
+@pytest.fixture
+def three_sessions(workouts_sheet):
+    """Three sessions across two gyms, in January, March and June."""
+    workouts_sheet(
+        workout_row(
+            location="Gym",
+            workout_time="2026-01-05T10:00:00",
+            exercise="Bench Press",
+            index="1",
+            weight_kg="50",
+            repetitions="10",
+        ),
+        workout_row(weight_kg="55", repetitions="8"),
+        workout_row(
+            location="Other",
+            workout_time="2026-03-05T10:00:00",
+            exercise="Crunch",
+            index="1",
+            weight_kg="60",
+            repetitions="12",
+        ),
+        workout_row(
+            location="Gym",
+            workout_time="2026-06-05T10:00:00",
+            exercise="Bench Press",
+            index="1",
+            weight_kg="70",
+            repetitions="6",
+        ),
+    )
+
+
+class TestLoadSessions:
+    """Test building the sessions the sets belong to."""
+
+    def test_one_session_per_location_and_time(self, three_sessions):
+        sessions = google_sheets.load_sessions_from_sheet(cfg=None)
+
+        assert len(sessions) == 3
+        assert [s.location_id for s in sessions] == [GYM, OTHER_GYM, GYM]
+
+    def test_the_id_is_derived_from_the_location_and_the_time(self, three_sessions):
+        """The backfill derives it the same way, which is what makes re-runs merge."""
+        sessions = google_sheets.load_sessions_from_sheet(cfg=None)
+
+        for session in sessions:
+            assert session.id == session_id_for(
+                location_id=session.location_id, workout_time=session.workout_time
+            )
+
+    def test_loading_twice_gives_the_same_ids(self, three_sessions):
+        first = google_sheets.load_sessions_from_sheet(cfg=None)
+        second = google_sheets.load_sessions_from_sheet(cfg=None)
+
+        assert [s.id for s in first] == [s.id for s in second]
+
+    def test_every_set_points_at_a_loaded_session(self, three_sessions):
+        sessions = google_sheets.load_sessions_from_sheet(cfg=None)
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert {w.session_id for w in workouts} <= {s.id for s in sessions}
+
+    def test_the_sets_of_one_session_share_its_id(self, three_sessions):
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None)
+
+        assert workouts[0].session_id == workouts[1].session_id
+        assert workouts[0].session_id != workouts[2].session_id
+
+
+class TestNarrowingTheLoad:
+    """Test the date and row ranges, which sessions and sets must agree on."""
+
+    def test_loading_after_a_date(self, three_sessions):
+        after = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
+
+        sessions = google_sheets.load_sessions_from_sheet(cfg=None, after=after)
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None, after=after)
+
+        assert len(sessions) == 2
+        assert len(workouts) == 2
+
+    def test_loading_before_a_date(self, three_sessions):
+        before = datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc)
+
+        sessions = google_sheets.load_sessions_from_sheet(cfg=None, before=before)
+
+        assert len(sessions) == 2
+
+    def test_loading_between_two_dates(self, three_sessions):
+        sessions = google_sheets.load_sessions_from_sheet(
+            cfg=None,
+            after=datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc),
+            before=datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc),
+        )
+
+        assert len(sessions) == 1
+        assert sessions[0].location_id == OTHER_GYM
+
+    def test_a_row_range_counts_the_header(self, three_sessions):
+        """range_end slices the raw sheet values, where row 1 is the header."""
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None, range_end=3)
+
+        assert len(workouts) == 2
+
+    def test_a_narrowed_range_still_inherits_from_the_rows_above(self, three_sessions):
+        """Starting partway down must not lose the session carried down to it."""
+        workouts = google_sheets.load_workouts_from_sheet(cfg=None, range_start=1)
+
+        assert workouts[0].exercise_id == BENCH
+        assert workouts[0].session_id == session_id_for(
+            location_id=GYM,
+            workout_time=datetime.datetime(
+                2026, 1, 5, 10, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+
+    def test_a_range_matching_nothing_is_empty(self, three_sessions):
+        after = datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc)
+
+        assert google_sheets.load_workouts_from_sheet(cfg=None, after=after) == []
+        assert google_sheets.load_sessions_from_sheet(cfg=None, after=after) == []

--- a/tests/test_workout_schema_validation.py
+++ b/tests/test_workout_schema_validation.py
@@ -14,9 +14,8 @@ class TestFloatValidation:
         """Test that NaN values are converted to None for optional float fields."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -33,9 +32,8 @@ class TestFloatValidation:
         """Test that 0.0 values are converted to None for optional float fields."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -52,9 +50,8 @@ class TestFloatValidation:
         """Test that valid positive float values are preserved."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -71,9 +68,8 @@ class TestFloatValidation:
         """Test that explicit None values are preserved."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -92,9 +88,8 @@ class TestFloatValidation:
         # Test valid values within boundaries
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -111,9 +106,8 @@ class TestFloatValidation:
         """Test that 0.0 weight_kg is allowed and preserved."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=0.0,  # Should be allowed
@@ -133,9 +127,8 @@ class TestDatetimeValidation:
         """Test that naive datetimes are converted to timezone-aware (UTC)."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0),  # Naive datetime
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -145,21 +138,18 @@ class TestDatetimeValidation:
             updated_at=datetime(2026, 6, 3, 0, 47, 31, 171989),  # Naive datetime
         )
 
-        assert workout.workout_time.tzinfo == timezone.utc
         assert workout.created_at.tzinfo == timezone.utc
         assert workout.updated_at.tzinfo == timezone.utc
 
     def test_aware_datetimes_preserved(self):
         """Test that timezone-aware datetimes are preserved."""
-        workout_time = datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc)
         created_at = datetime(2026, 6, 3, 0, 47, 31, tzinfo=timezone.utc)
         updated_at = datetime(2026, 6, 3, 0, 47, 31, tzinfo=timezone.utc)
 
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=workout_time,
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -169,7 +159,6 @@ class TestDatetimeValidation:
             updated_at=updated_at,
         )
 
-        assert workout.workout_time == workout_time
         assert workout.created_at == created_at
         assert workout.updated_at == updated_at
 
@@ -177,9 +166,8 @@ class TestDatetimeValidation:
         """Test that updated_at can be None (it's optional)."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -199,9 +187,8 @@ class TestCombinedValidation:
         """Test handling of all edge cases in a single workout record."""
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0),  # Naive datetime
             index=1,
             repetitions=10,
             weight_kg=0.0,  # 0.0 is allowed and preserved
@@ -220,7 +207,6 @@ class TestCombinedValidation:
         assert workout.supplementary_weight_kg is None
 
         # Datetime conversions
-        assert workout.workout_time.tzinfo == timezone.utc
         assert workout.created_at.tzinfo == timezone.utc
         assert workout.updated_at is None
 
@@ -232,9 +218,8 @@ class TestCombinedValidation:
         # Simulating what SQLAlchemy might return from the database
         workout = WorkoutResponse(
             id=uuid4(),
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0),  # DB returns naive
             index=1,
             repetitions=10,
             weight_kg=0.0,  # 0.0 in DB is preserved
@@ -249,7 +234,6 @@ class TestCombinedValidation:
         assert workout.weight_kg == 0.0  # Preserved from DB
         assert workout.bar_weight_kg is None
         assert workout.supplementary_weight_kg is None
-        assert workout.workout_time.tzinfo == timezone.utc
         assert workout.created_at.tzinfo == timezone.utc
         assert workout.updated_at.tzinfo == timezone.utc
 
@@ -260,9 +244,8 @@ class TestBaseWorkoutValidation:
     def test_base_workout_float_validation(self):
         """Test that float validation works in the base workout model."""
         workout = _BaseWorkout(
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=1,
             repetitions=10,
             weight_kg=50.0,
@@ -276,9 +259,8 @@ class TestBaseWorkoutValidation:
     def test_base_workout_valid_values(self):
         """Test that valid values work in the base workout model."""
         workout = _BaseWorkout(
-            location_id=uuid4(),
+            session_id=uuid4(),
             exercise_id=uuid4(),
-            workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
             index=5,
             repetitions=15,
             weight_kg=75.5,
@@ -303,9 +285,8 @@ class TestValidationErrors:
         with pytest.raises(Exception):  # Pydantic ValidationError
             WorkoutResponse(
                 id=uuid4(),
-                location_id=uuid4(),
+                session_id=uuid4(),
                 exercise_id=uuid4(),
-                workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
                 index=1,
                 repetitions=10,
                 weight_kg=-1000.0,  # Invalid: must be > -1000
@@ -320,9 +301,8 @@ class TestValidationErrors:
         with pytest.raises(Exception):  # Pydantic ValidationError
             WorkoutResponse(
                 id=uuid4(),
-                location_id=uuid4(),
+                session_id=uuid4(),
                 exercise_id=uuid4(),
-                workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
                 index=1,
                 repetitions=10,
                 weight_kg=50.0,
@@ -337,9 +317,8 @@ class TestValidationErrors:
         with pytest.raises(Exception):  # Pydantic ValidationError
             WorkoutResponse(
                 id=uuid4(),
-                location_id=uuid4(),
+                session_id=uuid4(),
                 exercise_id=uuid4(),
-                workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
                 index=0,  # Invalid: must be > 0
                 repetitions=10,
                 weight_kg=50.0,
@@ -354,9 +333,8 @@ class TestValidationErrors:
         with pytest.raises(Exception):  # Pydantic ValidationError
             WorkoutResponse(
                 id=uuid4(),
-                location_id=uuid4(),
+                session_id=uuid4(),
                 exercise_id=uuid4(),
-                workout_time=datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc),
                 index=1,
                 repetitions=150,  # Invalid: must be < 100
                 weight_kg=50.0,
@@ -373,9 +351,8 @@ class TestAssistedWeights:
     @staticmethod
     def _workout(**overrides) -> _BaseWorkout:
         payload = {
-            "location_id": uuid4(),
+            "session_id": uuid4(),
             "exercise_id": uuid4(),
-            "workout_time": datetime(2026, 8, 7, 14, 30, tzinfo=timezone.utc),
             "index": 1,
             "repetitions": 10,
             "weight_kg": 50.0,


### PR DESCRIPTION
A session was only implicit in the data: every set repeated the location and the time of the visit it belonged to — 1261 copies of 63 facts. There was nowhere to record anything *about* a session, nothing but convention stopping two sets at the same time claiming different locations, and a session was identified by a mutable timestamp.

## The change

```
sessions:  id, location_id → locations, workout_time, created_at, updated_at
           unique (location_id, workout_time)
workouts:  id, session_id → sessions, exercise_id, index, repetitions, weight_kg, …
```

`workouts` loses `location_id`, `workout_time`, and `exercise_index` (never populated, 0 of 1261 rows).

The revision backfills one session per location and time before making the column non-null. Its downgrade puts the columns back from the session, so the move is reversible with the data intact — verified both ways on a populated database.

## Derived session ids

The sheet has no session id, so it is derived: `uuid5` over a fixed namespace and `{location_id}|{time}Z`, normalised to UTC and truncated to the second.

The alembic backfill, the sheet loader and `POST /sessions` all share one implementation. **If they disagreed, every re-run of the sheet load would insert a duplicate of every session**, or collide with the unique constraint. Confirmed idempotent: running the full sheet migration twice leaves 63 sessions and 1261 workouts unchanged. The derivation is pinned in a test because it is now a contract — changing it orphans every existing session.

It also means a session is recoverable: deleted by mistake, recreating it from the same location and time restores the same id.

## Endpoints

| | |
| --- | --- |
| `POST /go-heavier/sessions` | create one to log sets against. `409` with the existing id if that visit already exists, `404` for an unknown location |
| `DELETE /go-heavier/sessions/{id}` | deletes the session and every set logged against it, in one transaction |
| `GET /go-heavier/sessions/stats` | aggregates *across* sessions, where `/sessions/{id}` aggregates within one |

`sessions/stats` answers what only makes sense at that granularity: averages per session, how often sessions happen, the longest gap, which weekday they fall on, and the busiest and heaviest of them. Gaps are null rather than zero below two sessions. The weekday breakdown converts to UK local time.

**No PUT.** Changing a session's location or time changes what its derived id *would* be, so an update either leaves the id disagreeing with its own derivation, or becomes a delete-and-recreate that orphans the sets. Delete and create again is at least explicit about that.

The delete cascade is explicit in the resolver rather than `ON DELETE CASCADE`, so it is visible where the deletion happens and cannot fire unnoticed from another path. Easy to move to the schema if preferred.

## Bugs fixed along the way

- **`POST /workouts` has never worked.** It declared `response_model=WorkoutResponse` while returning the list it created, so every call died in response validation. Now returns `List[WorkoutResponse]` with a 201.
- **`ListWorkoutsRequest` raised `TypeError` on any filtered request** — `exercise_id` and `location_id` were typed `UUID` but carried `min_length`, which pydantic cannot apply to a UUID. Fixed while rewriting it; also gains a `session_id` filter.
- **Empty sessions were unreadable.** The summary inner-joined the sets, so a session created before anything is logged against it was absent from the listing and a 404 on its own endpoint. The join is now outer and `heaviest_weight_kg` optional: nothing lifted is not the same as lifting zero.
- **`exercise_id` was silently never set.** Moving sessions and sets onto a shared frame dropped the rename of the sheet's `exercise` column. Nothing failed, because `merge()` skips an attribute that was never set and every row already existed, so the database kept its old value — the first genuinely new set would have hit the not-null constraint. Caught by the new loader tests, not by hand.

## Testing

189 tests, up from 136. Ruff, ruff format and isort clean.

The suite was entirely schema tests, so this adds the first tests of the loaders — where every data bug this week has lived, and which had only ever been checked by hand against the live spreadsheet. They import no database, so they run in CI as-is: forward fill, set numbering, a blank row not shifting that numbering, skipped incomplete rows, unmapped columns, blank notes staying null, negative weights, a typographic dash, UK local time, the derived ids, and the date and row ranges sessions and sets must agree on.

Verified against the real sheet and a populated database: migration backfills 63 sessions with no orphans, `alembic check` reports no drift, upgrade/downgrade/upgrade round-trips losslessly, the full sheet migration is idempotent across two runs, and every stats figure cross-checks against hand-written SQL. Create-then-log-then-delete round-trips, and a subsequent sheet migration is unaffected by an API-created session.

## Notes for review

- **Breaking:** `WorkoutResponse` no longer carries `location_id` or `workout_time`; it carries `session_id`, and callers fetch `/sessions/{id}` for the rest. `CreateWorkoutsRequest` takes `session_id`.
- **`alembic upgrade head` fails on a fresh database — and already does on `main`.** I reproduced it on `main` in a worktree: `add location data` merges live `Location` objects carrying `logo_url`, a column that does not exist yet at that revision. The historical data migrations import live models, so they drift from the schema of their time. This adds a second instance of that drift but is not the cause; existing databases upgrade fine. The clean fix is to make those three data migrations no-ops now that the same data loads through `POST /go-heavier/migrations` — happy to do that separately.
- **NaN is still stored** for `bar_weight_kg` and `supplementary_weight_kg`: the loader's `astype(float)` writes NaN rather than NULL for blank cells, masked on the way out by `convert_nan_to_none`.
- **CI cannot test any endpoint.** `.github/workflows/tests.yml` has no database, and `src/db.py` connects at import, so `src.main` cannot be imported there. Endpoint behaviour in this PR was verified by hand against SQL. A postgres service container plus a lazy connection would fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)