### PR TITLE
Run the tests and migrations against a throwaway database in CI

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -16,14 +16,3 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-  run-migrations:
-    name: Run migrations
-    runs-on: ubuntu-latest
-    concurrency: migrate-group    # optional: ensure only one action runs at a time
-    steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl ssh console -C "cd /app && alembic upgrade head"
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-    needs: deploy  # Ensure migrations run after deployment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,28 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # A throwaway database for this run only. Nothing here should ever point at
+    # the real one: the migrations are applied to it from empty, every time.
+    services:
+      postgres:
+        image: postgres:17.5-alpine3.21
+        env:
+          POSTGRES_USER: api
+          POSTGRES_PASSWORD: api
+          POSTGRES_DB: api_thesammy2010_com
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Takes precedence over the checked in .env, which load_dotenv will not
+      # override once the variable is already set.
+      DATABASE_URL: postgres://api:api@localhost:5432/api_thesammy2010_com
+
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -36,14 +58,18 @@ jobs:
     - name: Install dependencies
       run: poetry install --no-interaction --no-root
 
+    - name: Run migrations
+      run: poetry run alembic upgrade head
+
+    - name: Check the models match the migrations
+      run: poetry run alembic check
 
     - name: Run tests
-      run: poetry run pytest tests/ -v --tb=short
+      run: poetry run pytest tests/ -v --tb=short | tee pytest.log
 
     - name: Test Summary
       if: always()
       run: |
         echo "## Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        poetry run pytest tests/ -v --tb=short | tail -n 20 >> $GITHUB_STEP_SUMMARY || true
-
+        tail -n 20 pytest.log >> $GITHUB_STEP_SUMMARY || true

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ fly proxy 15432:5432 -a thesammy2010
 alembic upgrade head
 ```
 
+Deploying no longer runs these. `alembic upgrade head` has to be run against
+production deliberately, so a schema change and the deploy that needs it are not
+coupled to each other by accident.
+
+CI runs them from empty against a throwaway Postgres service container, never
+against a real database, and then runs `alembic check` so the models and the
+migrations cannot drift apart unnoticed.
+
 Try to use `alembic revision --autogenerate -m "message"` to create new migrations.
 
 ### db for local development

--- a/migrations/versions/2026_06_02_2228-ac52a7b2cd78_add_location_data.py
+++ b/migrations/versions/2026_06_02_2228-ac52a7b2cd78_add_location_data.py
@@ -6,13 +6,7 @@ Create Date: 2026-06-02 22:28:11.759058
 
 """
 
-import datetime
 from typing import Sequence, Union
-
-from src import db
-from src.config import Config
-from src.migration_utils.google_sheets import load_locations_from_sheet
-from src.models.go_heavier import Location, Workout
 
 # revision identifiers, used by Alembic.
 revision: str = "ac52a7b2cd78"
@@ -20,49 +14,18 @@ down_revision: Union[str, Sequence[str], None] = "1834e54859ea"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-cfg = Config()
-start = datetime.datetime.fromtimestamp(0).replace(tzinfo=datetime.timezone.utc)
-end = datetime.datetime(2026, 6, 2).replace(tzinfo=datetime.timezone.utc)
-
 
 def upgrade() -> None:
-    if cfg.google_service_account_filepath is None:
-        raise RuntimeError("Missing google service account file")
+    """Kept as a no-op.
 
-    locations = load_locations_from_sheet(cfg=cfg)
-    for filtered_location in filter(
-        lambda location: start <= location.created_at <= end, locations
-    ):
-        print("adding/updating {}".format(filtered_location))
-        # Update updated_at to now for merge operations
-        filtered_location.updated_at = datetime.datetime.now(datetime.timezone.utc)
-        db.session.merge(filtered_location)
-    db.session.commit()
+    This loaded the locations out of the Google Sheet using the model classes as they
+    were at the time. Those have moved on, so replaying it against the schema
+    of this revision fails, which broke `alembic upgrade head` on any new
+    database. The rows it added are long since in the databases that need
+    them, and the same load is available on demand through
+    POST /go-heavier/migrations.
+    """
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    if cfg.google_service_account_filepath is None:
-        raise RuntimeError("Missing google service account file")
-
-    locations = load_locations_from_sheet(cfg=cfg)
-    location_ids = [
-        location.id for location in locations if start <= location.created_at <= end
-    ]
-
-    if location_ids:
-        # First delete any workouts that reference these locations
-        workout_count = (
-            db.session.query(Workout)
-            .filter(Workout.location_id.in_(location_ids))
-            .delete(synchronize_session=False)
-        )
-        if workout_count > 0:
-            print(f"Deleted {workout_count} workouts referencing these locations")
-
-        # Then delete the locations
-        db.session.query(Location).filter(Location.id.in_(location_ids)).delete(
-            synchronize_session=False
-        )
-        db.session.commit()
-        print(f"Deleted {len(location_ids)} locations")
+    """Kept as a no-op, see upgrade."""

--- a/migrations/versions/2026_06_03_0050-c1e10239e50d_add_exercise_data.py
+++ b/migrations/versions/2026_06_03_0050-c1e10239e50d_add_exercise_data.py
@@ -6,13 +6,7 @@ Create Date: 2026-06-03 00:50:19.300413
 
 """
 
-import datetime
 from typing import Sequence, Union
-
-from src import db
-from src.config import Config
-from src.migration_utils.google_sheets import load_exercises_from_sheet
-from src.models.go_heavier import Exercise, Workout
 
 # revision identifiers, used by Alembic.
 revision: str = "c1e10239e50d"
@@ -21,49 +15,17 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-cfg = Config()
-start = datetime.datetime.fromtimestamp(0).replace(tzinfo=datetime.timezone.utc)
-end = datetime.datetime(2026, 6, 2).replace(tzinfo=datetime.timezone.utc)
-
-
 def upgrade() -> None:
-    if cfg.google_service_account_filepath is None:
-        raise RuntimeError("Missing google service account file")
+    """Kept as a no-op.
 
-    exercises = load_exercises_from_sheet(cfg=cfg)
-    for filtered_exercise in filter(
-        lambda exercise: start <= exercise.created_at <= end, exercises
-    ):
-        print("adding/updating {}".format(filtered_exercise))
-        # Update updated_at to now for merge operations
-        filtered_exercise.updated_at = datetime.datetime.now(datetime.timezone.utc)
-        db.session.merge(filtered_exercise)
-    db.session.commit()
+    This loaded the exercises out of the Google Sheet using the model classes as they
+    were at the time. Those have moved on, so replaying it against the schema
+    of this revision fails, which broke `alembic upgrade head` on any new
+    database. The rows it added are long since in the databases that need
+    them, and the same load is available on demand through
+    POST /go-heavier/migrations.
+    """
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    if cfg.google_service_account_filepath is None:
-        raise RuntimeError("Missing google service account file")
-
-    exercises = load_exercises_from_sheet(cfg=cfg)
-    exercise_ids = [
-        exercise.id for exercise in exercises if start <= exercise.created_at <= end
-    ]
-
-    if exercise_ids:
-        # First delete any workouts that reference these exercises
-        workout_count = (
-            db.session.query(Workout)
-            .filter(Workout.exercise_id.in_(exercise_ids))
-            .delete(synchronize_session=False)
-        )
-        if workout_count > 0:
-            print(f"Deleted {workout_count} workouts referencing these exercises")
-
-        # Then delete the exercises
-        db.session.query(Exercise).filter(Exercise.id.in_(exercise_ids)).delete(
-            synchronize_session=False
-        )
-        db.session.commit()
-        print(f"Deleted {len(exercise_ids)} exercises")
+    """Kept as a no-op, see upgrade."""

--- a/migrations/versions/2026_06_03_0103-9b3a6dc93a77_add_workout_data.py
+++ b/migrations/versions/2026_06_03_0103-9b3a6dc93a77_add_workout_data.py
@@ -6,13 +6,7 @@ Create Date: 2026-06-03 01:03:24.443041
 
 """
 
-import datetime
 from typing import Sequence, Union
-
-from src import db
-from src.config import Config
-from src.migration_utils.google_sheets import load_workouts_from_sheet
-from src.models.go_heavier import Workout
 
 # revision identifiers, used by Alembic.
 revision: str = "9b3a6dc93a77"
@@ -21,45 +15,17 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-cfg = Config()
-start = datetime.datetime.fromtimestamp(0).replace(tzinfo=datetime.timezone.utc)
-end = datetime.datetime(2026, 6, 2).replace(tzinfo=datetime.timezone.utc)
-range_start = 0
-range_end = 815
-
-
 def upgrade() -> None:
-    if cfg.google_service_account_filepath is None:
-        raise RuntimeError("Missing google service account file")
+    """Kept as a no-op.
 
-    workouts = load_workouts_from_sheet(
-        cfg=cfg, range_start=range_start, range_end=range_end
-    )
-    for filtered_workout in filter(
-        lambda workout: start <= workout.workout_time <= end, workouts
-    ):
-        print("adding/updating {}".format(filtered_workout))
-        # Update updated_at to now for merge operations
-        filtered_workout.updated_at = datetime.datetime.now(datetime.timezone.utc)
-        db.session.merge(filtered_workout)
-    db.session.commit()
+    This loaded the workouts out of the Google Sheet using the model classes as they
+    were at the time. Those have moved on, so replaying it against the schema
+    of this revision fails, which broke `alembic upgrade head` on any new
+    database. The rows it added are long since in the databases that need
+    them, and the same load is available on demand through
+    POST /go-heavier/migrations.
+    """
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    if cfg.google_service_account_filepath is None:
-        raise RuntimeError("Missing google service account file")
-
-    workouts = load_workouts_from_sheet(
-        cfg=cfg, range_start=range_start, range_end=range_end
-    )
-    workout_ids = [
-        workout.id for workout in workouts if start <= workout.created_at <= end
-    ]
-
-    if workout_ids:
-        db.session.query(Workout).filter(Workout.id.in_(workout_ids)).delete(
-            synchronize_session=False
-        )
-        db.session.commit()
-        print(f"Deleted {len(workout_ids)} workouts")
+    """Kept as a no-op, see upgrade."""


### PR DESCRIPTION
CI had no database at all, so it could only ever run the schema tests, and the migrations were never exercised until they reached production.

## What changes

A Postgres service container, matching the one in `docker-compose`. The migrations are applied to it **from empty**, then `alembic check` runs, then the tests.

```yaml
services:
  postgres:
    image: postgres:17.5-alpine3.21
env:
  DATABASE_URL: postgres://api:api@localhost:5432/api_thesammy2010_com
```

Set at job level so it takes precedence over the checked-in `.env` — `load_dotenv` will not override a variable that is already set. Nothing here can reach a real database.

`alembic check` is the part worth having: the models and the migrations can no longer drift apart without anyone noticing.

## The data migrations become no-ops

This was not possible while `alembic upgrade head` failed on any new database, which it has done for a while.

The three data migrations loaded the Google Sheet through the model classes *as they were at the time*. Those have moved on — `logo_url`, then `session_id` — so replaying them against the schema of their own revision fails:

```
Running upgrade 1834e54859ea -> ac52a7b2cd78, add location data
psycopg.errors.UndefinedColumn: column locations.logo_url does not exist
```

They are no-ops now, each carrying the reason. The rows they added are long since in the databases that need them, existing databases are already past these revisions so nothing replays, and the same load is available on demand through `POST /go-heavier/migrations`.

## Deploying no longer migrates production

The `run-migrations` job opened an ssh session into the running machine and ran `alembic upgrade head` there. Removed, as asked.

**This means production migrations are now manual.** A schema change will deploy without its migration unless `alembic upgrade head` is run deliberately. Noted in the README. If you would rather keep it automatic without ssh, Fly's `[deploy] release_command` in `fly.toml` runs it in a one-off machine before the new version goes live — one line, but a deploy-behaviour change worth choosing rather than having slipped in, so it is not in this PR.

## Also

The summary step re-ran the entire suite a second time just to collect its last twenty lines. It reads them from the first run now.

## Testing

Ran the CI steps locally in order, against a throwaway database, with the Google credentials unset exactly as CI has them:

- `alembic upgrade head` on an empty database succeeds through all six revisions, producing `locations`, `exercises`, `sessions`, `workouts`, `users`
- `alembic check` reports no drift
- 189 tests pass
- confirmed the run used the throwaway database and left the real one untouched

The `fly ssh console` in the README's "Connecting to the database" section is left alone — that is developer documentation, not a CI command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)