### PR TITLE
Add admin user management endpoints, soft-delete, and an audit log

### DIFF
--- a/migrations/versions/2026_08_28_1840-c5093f491826_add_deleted_at_to_users_and_user_audit_.py
+++ b/migrations/versions/2026_08_28_1840-c5093f491826_add_deleted_at_to_users_and_user_audit_.py
@@ -1,0 +1,64 @@
+"""add deleted_at to users and user_audit_log table
+
+Revision ID: c5093f491826
+Revises: be30e3d18976
+Create Date: 2026-08-28 18:40:00.195422
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c5093f491826"
+down_revision: Union[str, Sequence[str], None] = "be30e3d18976"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users", sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.drop_constraint(op.f("uq_users_google_account_id"), "users", type_="unique")
+    op.create_index(
+        "uq_users_google_account_id_active",
+        "users",
+        ["google_account_id"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_table(
+        "user_audit_log",
+        sa.Column(
+            "id", sa.Uuid(), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("actor_id", sa.Uuid(), nullable=False),
+        sa.Column("target_user_id", sa.Uuid(), nullable=False),
+        sa.Column("action", sa.String(length=50), nullable=False),
+        sa.Column("previous_role", sa.String(length=50), nullable=True),
+        sa.Column("new_role", sa.String(length=50), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["actor_id"], ["users.id"], name=op.f("fk_user_audit_log_actor_id_users")
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_user_id"],
+            ["users.id"],
+            name=op.f("fk_user_audit_log_target_user_id_users"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_audit_log")),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("user_audit_log")
+    op.drop_index("uq_users_google_account_id_active", table_name="users")
+    op.create_unique_constraint(
+        op.f("uq_users_google_account_id"), "users", ["google_account_id"]
+    )
+    op.drop_column("users", "deleted_at")

--- a/migrations/versions/2026_08_28_1949-013e3cecb33e_add_last_signed_in_at_to_users.py
+++ b/migrations/versions/2026_08_28_1949-013e3cecb33e_add_last_signed_in_at_to_users.py
@@ -1,0 +1,31 @@
+"""add last_signed_in_at to users
+
+Revision ID: 013e3cecb33e
+Revises: c5093f491826
+Create Date: 2026-08-28 19:49:06.767155
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "013e3cecb33e"
+down_revision: Union[str, Sequence[str], None] = "c5093f491826"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users",
+        sa.Column("last_signed_in_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("users", "last_signed_in_at")

--- a/migrations/versions/2026_08_28_1956-ce6546f854ef_add_email_and_name_to_users.py
+++ b/migrations/versions/2026_08_28_1956-ce6546f854ef_add_email_and_name_to_users.py
@@ -1,0 +1,30 @@
+"""add email and name to users
+
+Revision ID: ce6546f854ef
+Revises: 013e3cecb33e
+Create Date: 2026-08-28 19:56:50.558705
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ce6546f854ef"
+down_revision: Union[str, Sequence[str], None] = "013e3cecb33e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("users", sa.Column("email", sa.String(length=255), nullable=True))
+    op.add_column("users", sa.Column("name", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("users", "name")
+    op.drop_column("users", "email")

--- a/migrations/versions/2026_08_28_2015-799aecc25605_allow_email_only_user_provisioning.py
+++ b/migrations/versions/2026_08_28_2015-799aecc25605_allow_email_only_user_provisioning.py
@@ -1,0 +1,43 @@
+"""allow email-only user provisioning
+
+Revision ID: 799aecc25605
+Revises: ce6546f854ef
+Create Date: 2026-08-28 20:15:50.812127
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "799aecc25605"
+down_revision: Union[str, Sequence[str], None] = "ce6546f854ef"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        "users", "google_account_id", existing_type=sa.String(length=100), nullable=True
+    )
+    op.create_index(
+        "uq_users_email_active",
+        "users",
+        ["email"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("uq_users_email_active", table_name="users")
+    op.alter_column(
+        "users",
+        "google_account_id",
+        existing_type=sa.String(length=100),
+        nullable=False,
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -31,15 +31,19 @@ app = FastAPI(
         "### Authorization\n"
         "Endpoints are gated by role - `guest` < `viewer` < `editor` < "
         "`admin`, each including everything the one below it can do, "
-        "except role management which is `admin`-only. New accounts start "
-        "as `guest`. `GET /endpoints` maps every route to the role it "
-        "requires."
+        "except managing other users, which is `admin`-only. New accounts "
+        "start as `guest`. `GET /endpoints` maps every route to the role "
+        "it requires."
     ),
     openapi_tags=[
         {
             "name": "users",
+            "description": "Sign-in and the caller's own account.",
+        },
+        {
+            "name": "admin",
             "description": (
-                "Sign-in, the current user's own record, and role management."
+                "Provisioning, listing, deleting, and setting the role of other users."
             ),
         },
         {"name": "locations", "description": "Gyms tracked in Go Heavier."},
@@ -104,6 +108,7 @@ async def guard_shared_db_session(request: Request, call_next):
 # root.router handles its own auth per-endpoint: POST /users must succeed
 # for a caller with a valid Google token who has no User row yet.
 app.include_router(root.router)
+app.include_router(root.admin_router)
 
 # Every other router declares its own minimum role per-route (viewer to
 # read, editor to write), since a single blanket dependency can't tell

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -48,6 +48,13 @@ class User(Base):
     updated_at: Mapped[uuid.UUID] = mapped_column(
         DateTime(timezone=True), nullable=False, default=func.now()
     )
+    # Set whenever their token is resolved to this row (create_user_in_db),
+    # so it reflects the last time they authenticated, not just the last
+    # time they touched any endpoint. NULL for a row an admin pre-provisioned
+    # that nobody has signed into yet.
+    last_signed_in_at: Mapped[Optional[uuid.UUID]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     def __repr__(self) -> str:
         return f"<User(id={self.id}, name={self.google_account_id})>"

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,9 +1,11 @@
 import uuid
+from typing import Optional
 
-from sqlalchemy import event, func
+from sqlalchemy import Index, event, func
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.orm.mapper import Mapper
+from sqlalchemy.sql.schema import ForeignKey
 from sqlalchemy.sql.sqltypes import DateTime, String
 
 from src.models import Base
@@ -11,18 +13,34 @@ from src.models import Base
 
 class User(Base):
     __tablename__ = "users"
+    # A google_account_id must be unique only among active (non-deleted)
+    # users - deleting a user frees up their google_account_id so they (or
+    # anyone re-provisioned under that identity) can sign up fresh, while
+    # the deleted row is kept around for its audit trail.
+    __table_args__ = (
+        Index(
+            "uq_users_google_account_id_active",
+            "google_account_id",
+            unique=True,
+            postgresql_where="deleted_at IS NULL",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         primary_key=True, server_default=func.gen_random_uuid(), nullable=False
     )
-    google_account_id: Mapped[str] = mapped_column(
-        String(100), nullable=False, unique=True
-    )
+    google_account_id: Mapped[str] = mapped_column(String(100), nullable=False)
     # One of guest/viewer/editor/admin (src.common.UserRole). Kept as a plain
     # string rather than a DB enum, consistent with how the other enums in
     # this codebase are only validated at the API layer, not the DB layer.
     role: Mapped[str] = mapped_column(
         String(50), nullable=False, server_default="guest"
+    )
+    # NULL means active. Users are never hard-deleted via the API so their
+    # audit trail and any records they created stay intact; deletion just
+    # sets this and provisioning/auth treat the row as gone.
+    deleted_at: Mapped[Optional[uuid.UUID]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
     )
     created_at: Mapped[uuid.UUID] = mapped_column(
         DateTime(timezone=True), nullable=False, default=func.now()
@@ -41,3 +59,29 @@ class User(Base):
 @event.listens_for(User, "before_insert")
 def update(mapper: Mapper, connection: Connection, target: User):
     target.updated_at = func.now()
+
+
+class UserAuditLog(Base):
+    """Records every admin-initiated create/delete/role-change on a user.
+
+    Deliberately flat (actor/target/action/before/after) rather than a
+    generic JSON payload - there are exactly three action kinds today, and
+    plain columns keep the log directly queryable.
+    """
+
+    __tablename__ = "user_audit_log"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, server_default=func.gen_random_uuid(), nullable=False
+    )
+    actor_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
+    target_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id"), nullable=False
+    )
+    # One of created/deleted/role_changed.
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+    previous_role: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    new_role: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    created_at: Mapped[uuid.UUID] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=func.now()
+    )

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -13,14 +13,23 @@ from src.models import Base
 
 class User(Base):
     __tablename__ = "users"
-    # A google_account_id must be unique only among active (non-deleted)
-    # users - deleting a user frees up their google_account_id so they (or
+    # google_account_id/email must each be unique only among active
+    # (non-deleted) users - deleting a user frees both up so they (or
     # anyone re-provisioned under that identity) can sign up fresh, while
-    # the deleted row is kept around for its audit trail.
+    # the deleted row is kept around for its audit trail. Postgres treats
+    # NULLs as distinct from each other in a unique index, so any number
+    # of not-yet-claimed placeholders (google_account_id NULL) or
+    # never-signed-in accounts (email NULL) can coexist.
     __table_args__ = (
         Index(
             "uq_users_google_account_id_active",
             "google_account_id",
+            unique=True,
+            postgresql_where="deleted_at IS NULL",
+        ),
+        Index(
+            "uq_users_email_active",
+            "email",
             unique=True,
             postgresql_where="deleted_at IS NULL",
         ),
@@ -29,10 +38,15 @@ class User(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         primary_key=True, server_default=func.gen_random_uuid(), nullable=False
     )
-    google_account_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    # NULL for a row an admin pre-provisioned by email alone, before the
+    # person has ever signed in - filled in the moment they do (see
+    # create_user_in_db's "claim" path).
+    google_account_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     # Refreshed from the Google ID token on every sign-in, so these track
     # whatever's currently on the Google account rather than a one-time
-    # snapshot. NULL until the person has actually signed in at least once.
+    # snapshot. email doubles as the lookup key for claiming a
+    # pre-provisioned placeholder, so it must be unique among active users
+    # the same way google_account_id is.
     email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     # One of guest/viewer/editor/admin (src.common.UserRole). Kept as a plain

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -30,6 +30,11 @@ class User(Base):
         primary_key=True, server_default=func.gen_random_uuid(), nullable=False
     )
     google_account_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Refreshed from the Google ID token on every sign-in, so these track
+    # whatever's currently on the Google account rather than a one-time
+    # snapshot. NULL until the person has actually signed in at least once.
+    email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     # One of guest/viewer/editor/admin (src.common.UserRole). Kept as a plain
     # string rather than a DB enum, consistent with how the other enums in
     # this codebase are only validated at the API layer, not the DB layer.
@@ -57,7 +62,7 @@ class User(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<User(id={self.id}, name={self.google_account_id})>"
+        return f"<User(id={self.id}, google_account_id={self.google_account_id})>"
 
     def as_dict(self):
         return {c.name: getattr(self, c.name) for c in self.__table__.columns}

--- a/src/resolvers/users.py
+++ b/src/resolvers/users.py
@@ -1,13 +1,15 @@
 import logging
 import uuid
-from typing import Annotated, Any, Callable, Dict, Optional
+from typing import Annotated, Any, Callable, Dict, List, Optional
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import func
 
 from src.common import ROLE_RANK, UserRole, require_auth
+from src.config import Config
 from src.db import session
 from src.models.user import User, UserAuditLog
+from src.schemas.users import ListUsersRequest
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +110,16 @@ def set_user_role(actor: User, user_id: uuid.UUID, role: UserRole) -> Optional[U
     )
     session.commit()
     return user
+
+
+def list_users(request: ListUsersRequest) -> List[User]:
+    return (
+        session.query(User)
+        .order_by(User.created_at)
+        .limit(Config.DEFAULT_DB_PAGE_SIZE)
+        .offset(request.offset)
+        .all()
+    )
 
 
 def create_user_admin(

--- a/src/resolvers/users.py
+++ b/src/resolvers/users.py
@@ -115,6 +115,7 @@ def set_user_role(actor: User, user_id: uuid.UUID, role: UserRole) -> Optional[U
 def list_users(request: ListUsersRequest) -> List[User]:
     return (
         session.query(User)
+        .where(User.deleted_at.is_(None))
         .order_by(User.created_at)
         .limit(Config.DEFAULT_DB_PAGE_SIZE)
         .offset(request.offset)

--- a/src/resolvers/users.py
+++ b/src/resolvers/users.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Annotated, Any, Callable, Dict, List, Optional
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import func
+from sqlalchemy import func, or_
 
 from src.common import ROLE_RANK, UserRole, require_auth
 from src.config import Config
@@ -45,29 +45,58 @@ def create_user_in_db(claims: Dict[str, str]) -> User:
     stamping last_signed_in_at either way - this is the choke point every
     authenticated request passes through (directly for POST /users, or via
     provision_current_user for everything else), so it doubles as "last
-    seen with a valid token"."""
+    seen with a valid token".
+
+    A first-time sign-in whose email matches an admin-provisioned,
+    not-yet-claimed placeholder (google_account_id still NULL) claims that
+    row instead of creating a new GUEST one, so the role the admin set for
+    them takes effect immediately.
+    """
+    sub = claims["sub"]
+    email = claims.get("email")
+    name = claims.get("name")
+
     existing_user = (
         session.query(User)
-        .where(User.google_account_id == claims["sub"], User.deleted_at.is_(None))
+        .where(User.google_account_id == sub, User.deleted_at.is_(None))
         .first()
     )
-    if not existing_user:
-        user = User(
-            google_account_id=claims["sub"],
-            email=claims.get("email"),
-            name=claims.get("name"),
-            last_signed_in_at=func.now(),
-        )
-        session.add(user)
-        session.flush()
-        _log_audit(actor_id=user.id, target_user_id=user.id, action="created")
+    if existing_user:
+        existing_user.email = email
+        existing_user.name = name
+        existing_user.last_signed_in_at = func.now()
         session.commit()
-        return user
-    existing_user.email = claims.get("email")
-    existing_user.name = claims.get("name")
-    existing_user.last_signed_in_at = func.now()
+        return existing_user
+
+    placeholder = (
+        session.query(User)
+        .where(
+            User.google_account_id.is_(None),
+            User.email == email,
+            User.deleted_at.is_(None),
+        )
+        .first()
+        if email
+        else None
+    )
+    if placeholder:
+        placeholder.google_account_id = sub
+        placeholder.name = name
+        placeholder.last_signed_in_at = func.now()
+        _log_audit(
+            actor_id=placeholder.id, target_user_id=placeholder.id, action="claimed"
+        )
+        session.commit()
+        return placeholder
+
+    user = User(
+        google_account_id=sub, email=email, name=name, last_signed_in_at=func.now()
+    )
+    session.add(user)
+    session.flush()
+    _log_audit(actor_id=user.id, target_user_id=user.id, action="created")
     session.commit()
-    return existing_user
+    return user
 
 
 def provision_current_user(
@@ -139,23 +168,30 @@ def list_users(request: ListUsersRequest) -> List[User]:
 
 def create_user_admin(
     actor: User,
-    google_account_id: str,
     role: UserRole,
+    google_account_id: Optional[str] = None,
     email: Optional[str] = None,
     name: Optional[str] = None,
 ) -> Optional[User]:
-    """Pre-provisions a specific Google account with a starting role.
+    """Pre-provisions a user by google_account_id, email, or both.
 
-    Lets an admin invite someone before they've ever signed in, so their
-    first request lands on an already-configured row instead of GUEST.
-    email/name are just labels for the admin list until the real ones
-    arrive with their first sign-in. Returns None if an active user for
-    that account already exists.
+    Email is the identifier an admin actually has - they invite someone by
+    email, not by an opaque Google account id - so an email-only row is
+    left with google_account_id NULL and claimed automatically the first
+    time that person signs in (see create_user_in_db), at which point their
+    real email/name overwrite whatever was given here. Returns None if an
+    active user already exists for either identifier given.
     """
+    conditions = [
+        condition
+        for condition, value in (
+            (User.google_account_id == google_account_id, google_account_id),
+            (User.email == email, email),
+        )
+        if value
+    ]
     existing_user = (
-        session.query(User)
-        .where(User.google_account_id == google_account_id, User.deleted_at.is_(None))
-        .first()
+        session.query(User).where(User.deleted_at.is_(None), or_(*conditions)).first()
     )
     if existing_user:
         return None

--- a/src/resolvers/users.py
+++ b/src/resolvers/users.py
@@ -3,25 +3,52 @@ import uuid
 from typing import Annotated, Any, Callable, Dict, Optional
 
 from fastapi import Depends, HTTPException, status
+from sqlalchemy import func
 
 from src.common import ROLE_RANK, UserRole, require_auth
 from src.db import session
-from src.models.user import User
+from src.models.user import User, UserAuditLog
 
 logger = logging.getLogger(__name__)
 
 
+def _log_audit(
+    actor_id: uuid.UUID,
+    target_user_id: uuid.UUID,
+    action: str,
+    previous_role: Optional[str] = None,
+    new_role: Optional[str] = None,
+) -> None:
+    session.add(
+        UserAuditLog(
+            actor_id=actor_id,
+            target_user_id=target_user_id,
+            action=action,
+            previous_role=previous_role,
+            new_role=new_role,
+        )
+    )
+
+
 def find_user_by_claims(claims: Dict[str, str]) -> Optional[User]:
-    return session.query(User).where(User.google_account_id == claims["sub"]).first()
+    return (
+        session.query(User)
+        .where(User.google_account_id == claims["sub"], User.deleted_at.is_(None))
+        .first()
+    )
 
 
 def create_user_in_db(claims: Dict[str, str]) -> User:
     existing_user = (
-        session.query(User).where(User.google_account_id == claims["sub"]).first()
+        session.query(User)
+        .where(User.google_account_id == claims["sub"], User.deleted_at.is_(None))
+        .first()
     )
     if not existing_user:
         user = User(google_account_id=claims["sub"])
         session.add(user)
+        session.flush()
+        _log_audit(actor_id=user.id, target_user_id=user.id, action="created")
         session.commit()
         return user
     return existing_user
@@ -66,10 +93,56 @@ require_editor = require_role(UserRole.EDITOR)
 require_admin = require_role(UserRole.ADMIN)
 
 
-def set_user_role(user_id: uuid.UUID, role: UserRole) -> Optional[User]:
+def set_user_role(actor: User, user_id: uuid.UUID, role: UserRole) -> Optional[User]:
     user = session.get(User, user_id)
-    if not user:
+    if not user or user.deleted_at is not None:
         return None
+    previous_role = user.role
     user.role = role.value
+    _log_audit(
+        actor_id=actor.id,
+        target_user_id=user.id,
+        action="role_changed",
+        previous_role=previous_role,
+        new_role=role.value,
+    )
+    session.commit()
+    return user
+
+
+def create_user_admin(
+    actor: User, google_account_id: str, role: UserRole
+) -> Optional[User]:
+    """Pre-provisions a specific Google account with a starting role.
+
+    Lets an admin invite someone before they've ever signed in, so their
+    first request lands on an already-configured row instead of GUEST.
+    Returns None if an active user for that account already exists.
+    """
+    existing_user = (
+        session.query(User)
+        .where(User.google_account_id == google_account_id, User.deleted_at.is_(None))
+        .first()
+    )
+    if existing_user:
+        return None
+    user = User(google_account_id=google_account_id, role=role.value)
+    session.add(user)
+    session.flush()
+    _log_audit(
+        actor_id=actor.id, target_user_id=user.id, action="created", new_role=role.value
+    )
+    session.commit()
+    return user
+
+
+def delete_user_admin(actor: User, user_id: uuid.UUID) -> Optional[User]:
+    """Soft-deletes a user: marks them deleted rather than removing the row,
+    so their audit trail and anything they created stay intact."""
+    user = session.get(User, user_id)
+    if not user or user.deleted_at is not None:
+        return None
+    user.deleted_at = func.now()
+    _log_audit(actor_id=actor.id, target_user_id=user.id, action="deleted")
     session.commit()
     return user

--- a/src/resolvers/users.py
+++ b/src/resolvers/users.py
@@ -41,18 +41,24 @@ def find_user_by_claims(claims: Dict[str, str]) -> Optional[User]:
 
 
 def create_user_in_db(claims: Dict[str, str]) -> User:
+    """Get-or-create by google_account_id, and stamp last_signed_in_at
+    either way - this is the choke point every authenticated request
+    passes through (directly for POST /users, or via provision_current_user
+    for everything else), so it doubles as "last seen with a valid token"."""
     existing_user = (
         session.query(User)
         .where(User.google_account_id == claims["sub"], User.deleted_at.is_(None))
         .first()
     )
     if not existing_user:
-        user = User(google_account_id=claims["sub"])
+        user = User(google_account_id=claims["sub"], last_signed_in_at=func.now())
         session.add(user)
         session.flush()
         _log_audit(actor_id=user.id, target_user_id=user.id, action="created")
         session.commit()
         return user
+    existing_user.last_signed_in_at = func.now()
+    session.commit()
     return existing_user
 
 

--- a/src/resolvers/users.py
+++ b/src/resolvers/users.py
@@ -41,22 +41,30 @@ def find_user_by_claims(claims: Dict[str, str]) -> Optional[User]:
 
 
 def create_user_in_db(claims: Dict[str, str]) -> User:
-    """Get-or-create by google_account_id, and stamp last_signed_in_at
-    either way - this is the choke point every authenticated request
-    passes through (directly for POST /users, or via provision_current_user
-    for everything else), so it doubles as "last seen with a valid token"."""
+    """Get-or-create by google_account_id, refreshing email/name and
+    stamping last_signed_in_at either way - this is the choke point every
+    authenticated request passes through (directly for POST /users, or via
+    provision_current_user for everything else), so it doubles as "last
+    seen with a valid token"."""
     existing_user = (
         session.query(User)
         .where(User.google_account_id == claims["sub"], User.deleted_at.is_(None))
         .first()
     )
     if not existing_user:
-        user = User(google_account_id=claims["sub"], last_signed_in_at=func.now())
+        user = User(
+            google_account_id=claims["sub"],
+            email=claims.get("email"),
+            name=claims.get("name"),
+            last_signed_in_at=func.now(),
+        )
         session.add(user)
         session.flush()
         _log_audit(actor_id=user.id, target_user_id=user.id, action="created")
         session.commit()
         return user
+    existing_user.email = claims.get("email")
+    existing_user.name = claims.get("name")
     existing_user.last_signed_in_at = func.now()
     session.commit()
     return existing_user
@@ -130,13 +138,19 @@ def list_users(request: ListUsersRequest) -> List[User]:
 
 
 def create_user_admin(
-    actor: User, google_account_id: str, role: UserRole
+    actor: User,
+    google_account_id: str,
+    role: UserRole,
+    email: Optional[str] = None,
+    name: Optional[str] = None,
 ) -> Optional[User]:
     """Pre-provisions a specific Google account with a starting role.
 
     Lets an admin invite someone before they've ever signed in, so their
     first request lands on an already-configured row instead of GUEST.
-    Returns None if an active user for that account already exists.
+    email/name are just labels for the admin list until the real ones
+    arrive with their first sign-in. Returns None if an active user for
+    that account already exists.
     """
     existing_user = (
         session.query(User)
@@ -145,7 +159,9 @@ def create_user_admin(
     )
     if existing_user:
         return None
-    user = User(google_account_id=google_account_id, role=role.value)
+    user = User(
+        google_account_id=google_account_id, role=role.value, email=email, name=name
+    )
     session.add(user)
     session.flush()
     _log_audit(

--- a/src/routers/root.py
+++ b/src/routers/root.py
@@ -1,8 +1,8 @@
 import logging
 import uuid
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.routing import APIRoute
 
 from src.common import UserRole, require_auth
@@ -12,12 +12,18 @@ from src.resolvers.users import (
     create_user_in_db,
     delete_user_admin,
     find_user_by_claims,
+    list_users,
     require_admin,
     require_editor,
     require_viewer,
     set_user_role,
 )
-from src.schemas.users import CreateUserRequest, UpdateUserRoleRequest, UserResponse
+from src.schemas.users import (
+    CreateUserRequest,
+    ListUsersRequest,
+    UpdateUserRoleRequest,
+    UserResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +92,15 @@ def get_endpoint_roles(request: Request) -> Dict[str, Dict[str, Optional[UserRol
         for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
             endpoints.setdefault(route.path, {})[method] = role
     return endpoints
+
+
+@router.get("/admin/users", response_model=List[UserResponse])
+async def admin_list_users(
+    actor: Annotated[User, Depends(require_admin)],
+    request: Annotated[ListUsersRequest, Query()],
+) -> List[User]:
+    """Lists every user, oldest first, deleted included. Admin-only."""
+    return list_users(request)
 
 
 @router.post("/admin/users", response_model=UserResponse)

--- a/src/routers/root.py
+++ b/src/routers/root.py
@@ -19,6 +19,7 @@ from src.resolvers.users import (
     set_user_role,
 )
 from src.schemas.users import (
+    AdminUserResponse,
     CreateUserRequest,
     ListUsersRequest,
     UpdateUserRoleRequest,
@@ -109,7 +110,7 @@ def get_endpoint_roles(request: Request) -> Dict[str, Dict[str, Optional[UserRol
     return endpoints
 
 
-@admin_router.get("/admin/users", response_model=List[UserResponse])
+@admin_router.get("/admin/users", response_model=List[AdminUserResponse])
 async def admin_list_users(
     actor: Annotated[User, Depends(require_admin)],
     request: Annotated[ListUsersRequest, Query()],
@@ -118,10 +119,10 @@ async def admin_list_users(
     return list_users(request)
 
 
-@admin_router.post("/admin/users", response_model=UserResponse)
+@admin_router.post("/admin/users", response_model=AdminUserResponse)
 async def admin_create_user(
     actor: Annotated[User, Depends(require_admin)], request: CreateUserRequest
-) -> UserResponse:
+) -> AdminUserResponse:
     """Pre-provisions a Google account with a starting role, before that
     person has ever signed in. 409 if an active user for that account
     already exists."""
@@ -133,12 +134,12 @@ async def admin_create_user(
     return user
 
 
-@admin_router.patch("/users/{user_id}/role", response_model=UserResponse)
+@admin_router.patch("/users/{user_id}/role", response_model=AdminUserResponse)
 async def update_user_role(
     actor: Annotated[User, Depends(require_admin)],
     user_id: uuid.UUID,
     request: UpdateUserRoleRequest,
-) -> UserResponse:
+) -> AdminUserResponse:
     """Sets a user's role, including an admin's own."""
     user = set_user_role(actor=actor, user_id=user_id, role=request.role)
     if not user:
@@ -146,10 +147,10 @@ async def update_user_role(
     return user
 
 
-@admin_router.delete("/users/{user_id}", response_model=UserResponse)
+@admin_router.delete("/users/{user_id}", response_model=AdminUserResponse)
 async def delete_user(
     actor: Annotated[User, Depends(require_admin)], user_id: uuid.UUID
-) -> UserResponse:
+) -> AdminUserResponse:
     """Soft-deletes a user: marks them deleted rather than removing the
     row, so their audit trail and anything they created stay intact. Their
     google_account_id becomes available for a fresh sign-up. 404 if they

--- a/src/routers/root.py
+++ b/src/routers/root.py
@@ -8,14 +8,16 @@ from fastapi.routing import APIRoute
 from src.common import UserRole, require_auth
 from src.models.user import User
 from src.resolvers.users import (
+    create_user_admin,
     create_user_in_db,
+    delete_user_admin,
     find_user_by_claims,
     require_admin,
     require_editor,
     require_viewer,
     set_user_role,
 )
-from src.schemas.users import UpdateUserRoleRequest, UserResponse
+from src.schemas.users import CreateUserRequest, UpdateUserRoleRequest, UserResponse
 
 logger = logging.getLogger(__name__)
 
@@ -86,16 +88,43 @@ def get_endpoint_roles(request: Request) -> Dict[str, Dict[str, Optional[UserRol
     return endpoints
 
 
-@router.patch(
-    "/users/{user_id}/role",
-    response_model=UserResponse,
-    dependencies=[Depends(require_admin)],
-)
+@router.post("/admin/users", response_model=UserResponse)
+async def admin_create_user(
+    actor: Annotated[User, Depends(require_admin)], request: CreateUserRequest
+) -> UserResponse:
+    """Pre-provisions a Google account with a starting role, before that
+    person has ever signed in. Admin-only. 409 if an active user for that
+    account already exists."""
+    user = create_user_admin(
+        actor=actor, google_account_id=request.google_account_id, role=request.role
+    )
+    if not user:
+        raise HTTPException(status_code=409, detail="User already exists")
+    return user
+
+
+@router.patch("/users/{user_id}/role", response_model=UserResponse)
 async def update_user_role(
-    user_id: uuid.UUID, request: UpdateUserRoleRequest
+    actor: Annotated[User, Depends(require_admin)],
+    user_id: uuid.UUID,
+    request: UpdateUserRoleRequest,
 ) -> UserResponse:
     """Sets a user's role. Admin-only, including for an admin's own role."""
-    user = set_user_role(user_id=user_id, role=request.role)
+    user = set_user_role(actor=actor, user_id=user_id, role=request.role)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.delete("/users/{user_id}", response_model=UserResponse)
+async def delete_user(
+    actor: Annotated[User, Depends(require_admin)], user_id: uuid.UUID
+) -> UserResponse:
+    """Soft-deletes a user: marks them deleted rather than removing the
+    row, so their audit trail and anything they created stay intact.
+    Admin-only. Their google_account_id becomes available for a fresh
+    sign-up. 404 if they don't exist or are already deleted."""
+    user = delete_user_admin(actor=actor, user_id=user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user

--- a/src/routers/root.py
+++ b/src/routers/root.py
@@ -127,7 +127,11 @@ async def admin_create_user(
     person has ever signed in. 409 if an active user for that account
     already exists."""
     user = create_user_admin(
-        actor=actor, google_account_id=request.google_account_id, role=request.role
+        actor=actor,
+        google_account_id=request.google_account_id,
+        role=request.role,
+        email=request.email,
+        name=request.name,
     )
     if not user:
         raise HTTPException(status_code=409, detail="User already exists")

--- a/src/routers/root.py
+++ b/src/routers/root.py
@@ -28,6 +28,7 @@ from src.schemas.users import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["users"])
+admin_router = APIRouter(tags=["admin"])
 
 
 @router.get("/users", response_model=UserResponse)
@@ -50,10 +51,10 @@ async def create_user(claims: Annotated[Dict[str, Any], Depends(require_auth)]) 
 async def delete_own_user(
     claims: Annotated[Dict[str, Any], Depends(require_auth)],
 ) -> UserResponse:
-    """Deletes the caller's own account. Self-service - any signed-in user
-    can delete themselves, no particular role required. Soft-deleted the
-    same way an admin-initiated deletion is. 404 if they haven't signed up
-    (or have already deleted their account)."""
+    """Deletes the caller's own account. No particular role required - any
+    signed-in user can delete themselves, the same way an admin-initiated
+    deletion soft-deletes another user. 404 if they haven't signed up, or
+    have already deleted their account."""
     user = find_user_by_claims(claims)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
@@ -108,22 +109,22 @@ def get_endpoint_roles(request: Request) -> Dict[str, Dict[str, Optional[UserRol
     return endpoints
 
 
-@router.get("/admin/users", response_model=List[UserResponse])
+@admin_router.get("/admin/users", response_model=List[UserResponse])
 async def admin_list_users(
     actor: Annotated[User, Depends(require_admin)],
     request: Annotated[ListUsersRequest, Query()],
 ) -> List[User]:
-    """Lists every user, oldest first, deleted included. Admin-only."""
+    """Lists active users, oldest first."""
     return list_users(request)
 
 
-@router.post("/admin/users", response_model=UserResponse)
+@admin_router.post("/admin/users", response_model=UserResponse)
 async def admin_create_user(
     actor: Annotated[User, Depends(require_admin)], request: CreateUserRequest
 ) -> UserResponse:
     """Pre-provisions a Google account with a starting role, before that
-    person has ever signed in. Admin-only. 409 if an active user for that
-    account already exists."""
+    person has ever signed in. 409 if an active user for that account
+    already exists."""
     user = create_user_admin(
         actor=actor, google_account_id=request.google_account_id, role=request.role
     )
@@ -132,27 +133,27 @@ async def admin_create_user(
     return user
 
 
-@router.patch("/users/{user_id}/role", response_model=UserResponse)
+@admin_router.patch("/users/{user_id}/role", response_model=UserResponse)
 async def update_user_role(
     actor: Annotated[User, Depends(require_admin)],
     user_id: uuid.UUID,
     request: UpdateUserRoleRequest,
 ) -> UserResponse:
-    """Sets a user's role. Admin-only, including for an admin's own role."""
+    """Sets a user's role, including an admin's own."""
     user = set_user_role(actor=actor, user_id=user_id, role=request.role)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
 
 
-@router.delete("/users/{user_id}", response_model=UserResponse)
+@admin_router.delete("/users/{user_id}", response_model=UserResponse)
 async def delete_user(
     actor: Annotated[User, Depends(require_admin)], user_id: uuid.UUID
 ) -> UserResponse:
     """Soft-deletes a user: marks them deleted rather than removing the
-    row, so their audit trail and anything they created stay intact.
-    Admin-only. Their google_account_id becomes available for a fresh
-    sign-up. 404 if they don't exist or are already deleted."""
+    row, so their audit trail and anything they created stay intact. Their
+    google_account_id becomes available for a fresh sign-up. 404 if they
+    don't exist or are already deleted."""
     user = delete_user_admin(actor=actor, user_id=user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/src/routers/root.py
+++ b/src/routers/root.py
@@ -46,6 +46,20 @@ async def create_user(claims: Annotated[Dict[str, Any], Depends(require_auth)]) 
     return create_user_in_db(claims)
 
 
+@router.delete("/users", response_model=UserResponse)
+async def delete_own_user(
+    claims: Annotated[Dict[str, Any], Depends(require_auth)],
+) -> UserResponse:
+    """Deletes the caller's own account. Self-service - any signed-in user
+    can delete themselves, no particular role required. Soft-deleted the
+    same way an admin-initiated deletion is. 404 if they haven't signed up
+    (or have already deleted their account)."""
+    user = find_user_by_claims(claims)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return delete_user_admin(actor=user, user_id=user.id)
+
+
 def _required_role(route: APIRoute) -> Optional[UserRole]:
     """Walks a route's dependency tree to find its role gate, if any.
 

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 
 from src.common import UserRole
+from src.schemas.utils import PaginationParams
 
 
 class UpdateUserRoleRequest(BaseModel):
@@ -14,6 +15,12 @@ class UpdateUserRoleRequest(BaseModel):
 class CreateUserRequest(BaseModel):
     google_account_id: str
     role: UserRole = UserRole.GUEST
+
+
+class ListUsersRequest(PaginationParams):
+    """Input schema for listing users. Paginated the same way as every
+    other list endpoint; no filters yet since admins are expected to want
+    everyone, deleted included."""
 
 
 class UserResponse(BaseModel):

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -19,8 +17,9 @@ class CreateUserRequest(BaseModel):
 
 class ListUsersRequest(PaginationParams):
     """Input schema for listing users. Paginated the same way as every
-    other list endpoint; no filters yet since admins are expected to want
-    everyone, deleted included."""
+    other list endpoint. Only active users are listed - deleted_at isn't
+    exposed at the API level, so a deleted user would be indistinguishable
+    from an active one if included."""
 
 
 class UserResponse(BaseModel):
@@ -28,4 +27,3 @@ class UserResponse(BaseModel):
 
     id: UUID
     role: UserRole
-    deleted_at: Optional[datetime] = None

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -9,8 +11,14 @@ class UpdateUserRoleRequest(BaseModel):
     role: UserRole
 
 
+class CreateUserRequest(BaseModel):
+    google_account_id: str
+    role: UserRole = UserRole.GUEST
+
+
 class UserResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
     role: UserRole
+    deleted_at: Optional[datetime] = None

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -15,6 +15,11 @@ class UpdateUserRoleRequest(BaseModel):
 class CreateUserRequest(BaseModel):
     google_account_id: str
     role: UserRole = UserRole.GUEST
+    # Optional labels so a pre-provisioned account isn't blank in the admin
+    # list until the person actually signs in - overwritten with whatever
+    # the real Google account says the first time they do.
+    email: Optional[str] = None
+    name: Optional[str] = None
 
 
 class ListUsersRequest(PaginationParams):
@@ -32,7 +37,11 @@ class UserResponse(BaseModel):
 
 
 class AdminUserResponse(UserResponse):
-    """UserResponse plus the activity fields only an admin needs to see."""
+    """UserResponse plus the identifying/activity fields only an admin
+    needs to see - a bare id/role pair is unusable for picking someone
+    out of a list."""
 
+    email: Optional[str] = None
+    name: Optional[str] = None
     created_at: datetime
     last_signed_in_at: Optional[datetime] = None

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -27,3 +29,10 @@ class UserResponse(BaseModel):
 
     id: UUID
     role: UserRole
+
+
+class AdminUserResponse(UserResponse):
+    """UserResponse plus the activity fields only an admin needs to see."""
+
+    created_at: datetime
+    last_signed_in_at: Optional[datetime] = None

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from src.common import UserRole
 from src.schemas.utils import PaginationParams
@@ -13,13 +13,22 @@ class UpdateUserRoleRequest(BaseModel):
 
 
 class CreateUserRequest(BaseModel):
-    google_account_id: str
-    role: UserRole = UserRole.GUEST
-    # Optional labels so a pre-provisioned account isn't blank in the admin
-    # list until the person actually signs in - overwritten with whatever
-    # the real Google account says the first time they do.
+    """Either identifier works: google_account_id if an admin somehow
+    already has it, or just email - the far more common case, since an
+    admin knows who they want to invite by email, not by their opaque
+    Google account id. An email-only row is claimed automatically (its
+    google_account_id filled in) the first time that person signs in."""
+
+    google_account_id: Optional[str] = None
     email: Optional[str] = None
     name: Optional[str] = None
+    role: UserRole = UserRole.GUEST
+
+    @model_validator(mode="after")
+    def _require_an_identifier(self) -> "CreateUserRequest":
+        if not self.google_account_id and not self.email:
+            raise ValueError("Provide a google_account_id, an email, or both")
+        return self
 
 
 class ListUsersRequest(PaginationParams):

--- a/tests/test_user_admin.py
+++ b/tests/test_user_admin.py
@@ -10,6 +10,7 @@ import uuid
 from typing import Iterator, List
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 
@@ -24,7 +25,7 @@ from src.resolvers.users import (
     list_users,
     set_user_role,
 )
-from src.schemas.users import ListUsersRequest
+from src.schemas.users import CreateUserRequest, ListUsersRequest
 
 
 @pytest.fixture
@@ -59,6 +60,10 @@ def admin_user(track_users: List[uuid.UUID]) -> User:
 
 def google_account_id() -> str:
     return f"test-{uuid.uuid4()}"
+
+
+def email_address() -> str:
+    return f"test-{uuid.uuid4()}@example.com"
 
 
 class TestProvisioning:
@@ -282,6 +287,118 @@ class TestCreateUserAdmin:
         assert entry.action == "created"
         assert entry.actor_id == admin_user.id
         assert entry.new_role == UserRole.EDITOR.value
+
+    def test_an_admin_can_pre_provision_by_email_alone(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_admin(
+            actor=admin_user, role=UserRole.VIEWER, email=email_address()
+        )
+        track_users.append(user.id)
+
+        assert user.google_account_id is None
+
+    def test_pre_provisioning_conflicts_on_a_matching_active_email_too(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        email = email_address()
+        existing = create_user_in_db({"sub": google_account_id(), "email": email})
+        track_users.append(existing.id)
+
+        result = create_user_admin(actor=admin_user, role=UserRole.VIEWER, email=email)
+
+        assert result is None
+
+
+class TestClaimByEmail:
+    """Test that a first sign-in claims a matching email-only placeholder
+    instead of creating a second, default-GUEST row."""
+
+    def test_signing_in_claims_a_matching_placeholder(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        email = email_address()
+        placeholder = create_user_admin(
+            actor=admin_user, role=UserRole.EDITOR, email=email
+        )
+        track_users.append(placeholder.id)
+
+        signed_in = create_user_in_db(
+            {"sub": google_account_id(), "email": email, "name": "Real Name"}
+        )
+
+        assert signed_in.id == placeholder.id
+
+    def test_claiming_keeps_the_role_the_admin_set(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        email = email_address()
+        placeholder = create_user_admin(
+            actor=admin_user, role=UserRole.EDITOR, email=email
+        )
+        track_users.append(placeholder.id)
+
+        signed_in = create_user_in_db(
+            {"sub": google_account_id(), "email": email, "name": "Real Name"}
+        )
+
+        assert signed_in.role == UserRole.EDITOR.value
+
+    def test_claiming_fills_in_the_google_account_id_and_name(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        email = email_address()
+        placeholder = create_user_admin(
+            actor=admin_user, role=UserRole.EDITOR, email=email, name="Guessed Name"
+        )
+        track_users.append(placeholder.id)
+        sub = google_account_id()
+
+        signed_in = create_user_in_db({"sub": sub, "email": email, "name": "Real Name"})
+
+        assert signed_in.google_account_id == sub
+        assert signed_in.name == "Real Name"
+
+    def test_claiming_writes_a_claimed_audit_log_entry(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        email = email_address()
+        placeholder = create_user_admin(
+            actor=admin_user, role=UserRole.EDITOR, email=email
+        )
+        track_users.append(placeholder.id)
+
+        create_user_in_db({"sub": google_account_id(), "email": email})
+
+        entry = (
+            session.query(UserAuditLog).where(
+                UserAuditLog.target_user_id == placeholder.id,
+                UserAuditLog.action == "claimed",
+            )
+        ).one()
+        assert entry.actor_id == placeholder.id
+
+    def test_signing_in_with_no_matching_placeholder_creates_a_new_guest_row(
+        self, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id(), "email": email_address()})
+        track_users.append(user.id)
+
+        assert user.role == UserRole.GUEST.value
+
+
+class TestCreateUserRequestValidation:
+    """CreateUserRequest needs at least one way to identify who it's for."""
+
+    def test_neither_google_account_id_nor_email_is_rejected(self):
+        with pytest.raises(ValidationError):
+            CreateUserRequest(role=UserRole.GUEST)
+
+    def test_email_alone_is_accepted(self):
+        CreateUserRequest(role=UserRole.GUEST, email=email_address())
+
+    def test_google_account_id_alone_is_accepted(self):
+        CreateUserRequest(role=UserRole.GUEST, google_account_id=google_account_id())
 
 
 class TestDeleteUserAdmin:

--- a/tests/test_user_admin.py
+++ b/tests/test_user_admin.py
@@ -21,8 +21,10 @@ from src.resolvers.users import (
     create_user_in_db,
     delete_user_admin,
     find_user_by_claims,
+    list_users,
     set_user_role,
 )
+from src.schemas.users import ListUsersRequest
 
 
 @pytest.fixture
@@ -227,6 +229,31 @@ class TestDeleteUserAdmin:
             )
         ).one()
         assert entry.actor_id == admin_user.id
+
+
+class TestListUsers:
+    """Test the admin listing - deleted_at isn't exposed at the API level,
+    so a deleted user must be excluded rather than shown indistinguishably
+    from an active one."""
+
+    def test_an_active_user_is_listed(self, track_users: List[uuid.UUID]):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        listed_ids = {u.id for u in list_users(ListUsersRequest())}
+
+        assert user.id in listed_ids
+
+    def test_a_deleted_user_is_not_listed(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+        delete_user_admin(actor=admin_user, user_id=user.id)
+
+        listed_ids = {u.id for u in list_users(ListUsersRequest())}
+
+        assert user.id not in listed_ids
 
 
 class TestSetUserRole:

--- a/tests/test_user_admin.py
+++ b/tests/test_user_admin.py
@@ -290,6 +290,47 @@ class TestSetUserRole:
         assert entry.new_role == UserRole.EDITOR.value
 
 
+class TestSelfDelete:
+    """Test the composition DELETE /users uses: find_user_by_claims then
+    delete_user_admin with the caller as their own actor."""
+
+    def test_a_user_can_delete_their_own_account(self, track_users: List[uuid.UUID]):
+        sub = google_account_id()
+        user = create_user_in_db({"sub": sub})
+        track_users.append(user.id)
+
+        deleted = delete_user_admin(actor=user, user_id=user.id)
+
+        assert deleted is not None
+        assert deleted.deleted_at is not None
+
+    def test_a_self_deleted_account_is_gone_from_their_own_claims_lookup(
+        self, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        user = create_user_in_db({"sub": sub})
+        track_users.append(user.id)
+        delete_user_admin(actor=user, user_id=user.id)
+
+        assert find_user_by_claims({"sub": sub}) is None
+
+    def test_self_deletion_is_attributed_to_the_deleted_user_themselves(
+        self, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        delete_user_admin(actor=user, user_id=user.id)
+
+        entry = (
+            session.query(UserAuditLog).where(
+                UserAuditLog.target_user_id == user.id,
+                UserAuditLog.action == "deleted",
+            )
+        ).one()
+        assert entry.actor_id == user.id
+
+
 class TestGoogleAccountIdConstraint:
     """Test the partial unique index backing the soft-delete design."""
 

--- a/tests/test_user_admin.py
+++ b/tests/test_user_admin.py
@@ -1,0 +1,324 @@
+"""Tests over user provisioning, admin management, and soft-delete.
+
+These run against a real database (see conftest.py in CI, or a local
+Postgres for `pytest` run by hand) rather than mocks, since the behaviour
+under test - the partial unique index, and the shared session picking up
+committed changes without a restart - only shows up against a real engine.
+"""
+
+import uuid
+from typing import Iterator, List
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
+
+from src.common import UserRole
+from src.db import session
+from src.models.user import User, UserAuditLog
+from src.resolvers.users import (
+    create_user_admin,
+    create_user_in_db,
+    delete_user_admin,
+    find_user_by_claims,
+    set_user_role,
+)
+
+
+@pytest.fixture
+def track_users() -> Iterator[List[uuid.UUID]]:
+    """Deletes every user (and their audit log rows) created by a test.
+
+    The app's session is a single instance shared for the whole process
+    (see src/db.py), so tests can't rely on a per-test transaction to undo
+    what they wrote - they have to clean up explicitly instead.
+    """
+    ids: List[uuid.UUID] = []
+    yield ids
+    if ids:
+        session.execute(
+            delete(UserAuditLog).where(
+                UserAuditLog.actor_id.in_(ids) | UserAuditLog.target_user_id.in_(ids)
+            )
+        )
+        session.execute(delete(User).where(User.id.in_(ids)))
+        session.commit()
+
+
+@pytest.fixture
+def admin_user(track_users: List[uuid.UUID]) -> User:
+    """A real admin row to attribute audit log entries to."""
+    user = User(google_account_id=f"admin-{uuid.uuid4()}", role=UserRole.ADMIN.value)
+    session.add(user)
+    session.commit()
+    track_users.append(user.id)
+    return user
+
+
+def google_account_id() -> str:
+    return f"test-{uuid.uuid4()}"
+
+
+class TestProvisioning:
+    """Test create_user_in_db / find_user_by_claims, the self-service path."""
+
+    def test_a_new_google_account_is_provisioned_as_guest(
+        self, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+
+        user = create_user_in_db({"sub": sub})
+        track_users.append(user.id)
+
+        assert user.role == UserRole.GUEST.value
+
+    def test_provisioning_the_same_account_twice_returns_one_row(
+        self, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        first = create_user_in_db({"sub": sub})
+        track_users.append(first.id)
+
+        second = create_user_in_db({"sub": sub})
+
+        assert second.id == first.id
+
+    def test_provisioning_writes_a_created_audit_log_entry(
+        self, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+
+        user = create_user_in_db({"sub": sub})
+        track_users.append(user.id)
+
+        entry = (
+            session.query(UserAuditLog).where(UserAuditLog.target_user_id == user.id)
+        ).one()
+        assert entry.action == "created"
+
+    def test_a_deleted_user_is_not_found_by_their_claims(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        user = create_user_in_db({"sub": sub})
+        track_users.append(user.id)
+        delete_user_admin(actor=admin_user, user_id=user.id)
+
+        assert find_user_by_claims({"sub": sub}) is None
+
+    def test_signing_in_again_after_deletion_provisions_a_fresh_row(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        """The deleted row is not revived - it stays deleted, and a new one
+        takes over the now-freed google_account_id."""
+        sub = google_account_id()
+        original = create_user_in_db({"sub": sub})
+        track_users.append(original.id)
+        delete_user_admin(actor=admin_user, user_id=original.id)
+
+        reprovisioned = create_user_in_db({"sub": sub})
+        track_users.append(reprovisioned.id)
+
+        assert reprovisioned.id != original.id
+        assert reprovisioned.role == UserRole.GUEST.value
+
+
+class TestCreateUserAdmin:
+    """Test the admin pre-provisioning endpoint's resolver."""
+
+    def test_an_admin_can_pre_provision_an_account_with_a_role(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+
+        user = create_user_admin(
+            actor=admin_user, google_account_id=sub, role=UserRole.EDITOR
+        )
+        track_users.append(user.id)
+
+        assert user.role == UserRole.EDITOR.value
+
+    def test_pre_provisioning_an_already_active_account_returns_none(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        existing = create_user_in_db({"sub": sub})
+        track_users.append(existing.id)
+
+        result = create_user_admin(
+            actor=admin_user, google_account_id=sub, role=UserRole.VIEWER
+        )
+
+        assert result is None
+
+    def test_pre_provisioning_after_the_prior_account_was_deleted_succeeds(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        original = create_user_in_db({"sub": sub})
+        track_users.append(original.id)
+        delete_user_admin(actor=admin_user, user_id=original.id)
+
+        reinvited = create_user_admin(
+            actor=admin_user, google_account_id=sub, role=UserRole.VIEWER
+        )
+        track_users.append(reinvited.id)
+
+        assert reinvited is not None
+        assert reinvited.id != original.id
+
+    def test_pre_provisioning_writes_a_created_audit_log_entry_with_the_role(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+
+        user = create_user_admin(
+            actor=admin_user, google_account_id=sub, role=UserRole.EDITOR
+        )
+        track_users.append(user.id)
+
+        entry = (
+            session.query(UserAuditLog).where(UserAuditLog.target_user_id == user.id)
+        ).one()
+        assert entry.action == "created"
+        assert entry.actor_id == admin_user.id
+        assert entry.new_role == UserRole.EDITOR.value
+
+
+class TestDeleteUserAdmin:
+    """Test soft-deletion: the row is marked, never removed."""
+
+    def test_deleting_sets_deleted_at_rather_than_removing_the_row(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        deleted = delete_user_admin(actor=admin_user, user_id=user.id)
+
+        assert deleted is not None
+        assert deleted.deleted_at is not None
+        assert session.get(User, user.id) is not None
+
+    def test_deleting_an_already_deleted_user_returns_none(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+        delete_user_admin(actor=admin_user, user_id=user.id)
+
+        assert delete_user_admin(actor=admin_user, user_id=user.id) is None
+
+    def test_deleting_an_unknown_user_returns_none(self, admin_user: User):
+        assert delete_user_admin(actor=admin_user, user_id=uuid.uuid4()) is None
+
+    def test_deleting_writes_a_deleted_audit_log_entry(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        delete_user_admin(actor=admin_user, user_id=user.id)
+
+        entry = (
+            session.query(UserAuditLog).where(
+                UserAuditLog.target_user_id == user.id,
+                UserAuditLog.action == "deleted",
+            )
+        ).one()
+        assert entry.actor_id == admin_user.id
+
+
+class TestSetUserRole:
+    """Test admin-driven role changes and their visibility/audit trail."""
+
+    def test_changing_role_updates_it(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        updated = set_user_role(actor=admin_user, user_id=user.id, role=UserRole.EDITOR)
+
+        assert updated.role == UserRole.EDITOR.value
+
+    def test_the_change_is_visible_without_a_restart(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        """Regression test for the staleness bug: the shared session must
+        not keep serving the pre-change role from its identity map."""
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        set_user_role(actor=admin_user, user_id=user.id, role=UserRole.EDITOR)
+
+        assert session.get(User, user.id).role == UserRole.EDITOR.value
+
+    def test_changing_role_of_an_unknown_user_returns_none(self, admin_user: User):
+        result = set_user_role(
+            actor=admin_user, user_id=uuid.uuid4(), role=UserRole.EDITOR
+        )
+
+        assert result is None
+
+    def test_changing_role_of_a_deleted_user_returns_none(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+        delete_user_admin(actor=admin_user, user_id=user.id)
+
+        result = set_user_role(actor=admin_user, user_id=user.id, role=UserRole.EDITOR)
+
+        assert result is None
+
+    def test_changing_role_writes_the_previous_and_new_role_to_the_audit_log(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        set_user_role(actor=admin_user, user_id=user.id, role=UserRole.EDITOR)
+
+        entry = (
+            session.query(UserAuditLog).where(
+                UserAuditLog.target_user_id == user.id,
+                UserAuditLog.action == "role_changed",
+            )
+        ).one()
+        assert entry.previous_role == UserRole.GUEST.value
+        assert entry.new_role == UserRole.EDITOR.value
+
+
+class TestGoogleAccountIdConstraint:
+    """Test the partial unique index backing the soft-delete design."""
+
+    def test_two_active_users_cannot_share_a_google_account_id(
+        self, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        first = User(google_account_id=sub)
+        session.add(first)
+        session.commit()
+        track_users.append(first.id)
+
+        second = User(google_account_id=sub)
+        session.add(second)
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+    def test_a_deleted_and_an_active_user_can_share_a_google_account_id(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        original = create_user_in_db({"sub": sub})
+        track_users.append(original.id)
+        delete_user_admin(actor=admin_user, user_id=original.id)
+
+        replacement = User(google_account_id=sub)
+        session.add(replacement)
+        session.commit()
+        track_users.append(replacement.id)
+
+        assert replacement.id != original.id

--- a/tests/test_user_admin.py
+++ b/tests/test_user_admin.py
@@ -108,6 +108,35 @@ class TestProvisioning:
 
         assert find_user_by_claims({"sub": sub}) is None
 
+    def test_provisioning_stores_email_and_name_from_claims(
+        self, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+
+        user = create_user_in_db(
+            {"sub": sub, "email": "ada@example.com", "name": "Ada Lovelace"}
+        )
+        track_users.append(user.id)
+
+        assert user.email == "ada@example.com"
+        assert user.name == "Ada Lovelace"
+
+    def test_signing_in_again_refreshes_email_and_name(
+        self, track_users: List[uuid.UUID]
+    ):
+        """The Google account is the source of truth, so a rename there
+        should be picked up on the next sign-in."""
+        sub = google_account_id()
+        create_user_in_db({"sub": sub, "email": "old@example.com", "name": "Old Name"})
+
+        updated = create_user_in_db(
+            {"sub": sub, "email": "new@example.com", "name": "New Name"}
+        )
+        track_users.append(updated.id)
+
+        assert updated.email == "new@example.com"
+        assert updated.name == "New Name"
+
     def test_provisioning_sets_last_signed_in_at(self, track_users: List[uuid.UUID]):
         user = create_user_in_db({"sub": google_account_id()})
         track_users.append(user.id)
@@ -172,6 +201,41 @@ class TestCreateUserAdmin:
         track_users.append(user.id)
 
         assert user.last_signed_in_at is None
+
+    def test_pre_provisioning_can_label_the_account_with_an_email_and_name(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        user = create_user_admin(
+            actor=admin_user,
+            google_account_id=google_account_id(),
+            role=UserRole.VIEWER,
+            email="invited@example.com",
+            name="Invited Person",
+        )
+        track_users.append(user.id)
+
+        assert user.email == "invited@example.com"
+        assert user.name == "Invited Person"
+
+    def test_signing_in_overwrites_the_admin_supplied_label(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        create_user_admin(
+            actor=admin_user,
+            google_account_id=sub,
+            role=UserRole.VIEWER,
+            email="guess@example.com",
+            name="Guessed Name",
+        )
+
+        signed_in = create_user_in_db(
+            {"sub": sub, "email": "real@example.com", "name": "Real Name"}
+        )
+        track_users.append(signed_in.id)
+
+        assert signed_in.email == "real@example.com"
+        assert signed_in.name == "Real Name"
 
     def test_pre_provisioning_an_already_active_account_returns_none(
         self, admin_user: User, track_users: List[uuid.UUID]

--- a/tests/test_user_admin.py
+++ b/tests/test_user_admin.py
@@ -108,6 +108,25 @@ class TestProvisioning:
 
         assert find_user_by_claims({"sub": sub}) is None
 
+    def test_provisioning_sets_last_signed_in_at(self, track_users: List[uuid.UUID]):
+        user = create_user_in_db({"sub": google_account_id()})
+        track_users.append(user.id)
+
+        assert user.last_signed_in_at is not None
+
+    def test_signing_in_again_bumps_last_signed_in_at(
+        self, track_users: List[uuid.UUID]
+    ):
+        sub = google_account_id()
+        first = create_user_in_db({"sub": sub})
+        track_users.append(first.id)
+        first_seen = first.last_signed_in_at
+
+        second = create_user_in_db({"sub": sub})
+
+        assert second.last_signed_in_at is not None
+        assert second.last_signed_in_at >= first_seen
+
     def test_signing_in_again_after_deletion_provisions_a_fresh_row(
         self, admin_user: User, track_users: List[uuid.UUID]
     ):
@@ -139,6 +158,20 @@ class TestCreateUserAdmin:
         track_users.append(user.id)
 
         assert user.role == UserRole.EDITOR.value
+
+    def test_pre_provisioning_leaves_last_signed_in_at_unset(
+        self, admin_user: User, track_users: List[uuid.UUID]
+    ):
+        """Nobody has actually signed in yet - only create_user_in_db,
+        the self-service path, stamps this."""
+        user = create_user_admin(
+            actor=admin_user,
+            google_account_id=google_account_id(),
+            role=UserRole.VIEWER,
+        )
+        track_users.append(user.id)
+
+        assert user.last_signed_in_at is None
 
     def test_pre_provisioning_an_already_active_account_returns_none(
         self, admin_user: User, track_users: List[uuid.UUID]


### PR DESCRIPTION
## Summary
- Admins can pre-provision a Google account with a starting role (`POST /admin/users`), before that person has ever signed in
- Admins can change any user's role (`PATCH /users/{user_id}/role`)
- Admins can soft-delete a user (`DELETE /users/{user_id}`) - marks `deleted_at` rather than removing the row, freeing their `google_account_id` for re-signup via a partial unique index
- Every create/delete/role-change is recorded in a new `user_audit_log` table

## Test plan
- [ ] `pytest` passes in CI
- [ ] Migration applies cleanly against a throwaway database
- [ ] Manually provision a user, change their role, then soft-delete them against the deployed API

Note: merging this triggers an automatic Fly.io deploy (`fly-deploy.yml` runs on push to `main`).