### PR TITLE
Restrict the Go Heavier sheet-import endpoint to admin

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -112,7 +112,8 @@ app.include_router(root.admin_router)
 
 # Every other router declares its own minimum role per-route (viewer to
 # read, editor to write), since a single blanket dependency can't tell
-# GET from POST/PUT/DELETE apart.
+# GET from POST/PUT/DELETE apart. Migrations is the exception - it can
+# overwrite real data from an external sheet, so it's admin-only.
 app.include_router(locations.router)
 app.include_router(exercises.router)
 app.include_router(workouts.router)

--- a/src/routers/go_heavier/migrations.py
+++ b/src/routers/go_heavier/migrations.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from src.resolvers.go_heavier import migrations
 from src.resolvers.go_heavier.migrations import MigrationConfigurationError
-from src.resolvers.users import require_editor
+from src.resolvers.users import require_admin
 from src.schemas.go_heavier.migrations import (
     RunMigrationRequest,
     RunMigrationResponse,
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/go-heavier", tags=["migrations"])
 @router.post(
     "/migrations",
     response_model=RunMigrationResponse,
-    dependencies=[Depends(require_editor)],
+    dependencies=[Depends(require_admin)],
 )
 def run_migration(request: RunMigrationRequest) -> RunMigrationResponse:
     """Upserts rows from the Go Heavier Google Sheet into the database.


### PR DESCRIPTION
## Summary
- `POST /go-heavier/migrations` now requires `admin` instead of `editor`. It overwrites real location/exercise/session/workout data from an external Google Sheet, which is a bigger blast radius than the per-record create/update/delete `editor` is meant to allow.

## Test plan
- [x] `pytest` (247 passing)
- [x] `ruff check`, `ruff format --check`, `isort --check-only`
- [x] `GET /endpoints` derives its role report by identity-matching the dependency function, so it will automatically report `admin` for this route without any separate list to keep in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)